### PR TITLE
create instrument and instrument change tables

### DIFF
--- a/server/db/schema/instrument.sql
+++ b/server/db/schema/instrument.sql
@@ -1,0 +1,5 @@
+
+CREATE TABLE instrument (
+  id BIGSERIAL PRIMARY KEY,
+  name VARCHAR(70) NOT NULL
+);

--- a/server/db/schema/instrument_change.sql
+++ b/server/db/schema/instrument_change.sql
@@ -1,0 +1,19 @@
+
+
+
+CREATE TABLE instrument_change (
+  id BIGSERIAL PRIMARY KEY,
+
+  instrument_id BIGINT NOT NULL,
+  update_id BIGINT NOT NULL,
+  amount_changed SMALLINT NOT NULL,
+  
+    CONSTRAINT fk_instrument
+      FOREIGN KEY (instrument_id) 
+        REFERENCES instrument(id)
+          ON DELETE CASCADE,
+    CONSTRAINT fk_update
+      FOREIGN KEY (update_id)
+        REFERENCES update(id)
+          ON DELETE CASCADE
+  );


### PR DESCRIPTION
## Description

- implemented SQL schemas for instrument and instrument_change
- tested using db fiddle and dummy data

## Screenshots/Media
<img width="868" height="844" alt="Screenshot 2025-11-26 at 8 29 26 AM" src="https://github.com/user-attachments/assets/c4300f60-70ee-4f11-be6f-6ab1887b31d0" />
<img width="868" height="844" alt="Screenshot 2025-11-26 at 8 29 35 AM" src="https://github.com/user-attachments/assets/43e10c89-491a-4b55-bdb2-222c7059c2a3" />

## Issues
Closes #10 

## Additional Notes
We were wondering if there was specific reasoning for using BIGSERIAL in the instrument_id and update_id types. From my understanding BIGSERIAL would create auto-incrementing extra sequences instead of matching the existing IDs in the referenced table. 
