### PR TITLE
Created User RD PD Tables

### DIFF
--- a/server/db/schema/program_director.sql
+++ b/server/db/schema/program_director.sql
@@ -1,6 +1,13 @@
 CREATE TABLE IF NOT EXISTS program_director (
-    user_id BIGSERIAL,
-    program_id BIGSERIAL,
-    FOREIGN KEY (user_id) REFERENCES user(id),
-    FOREIGN KEY (program_id) REFERENCES program(id)
+    user_id BIGINT,
+    program_id BIGINT,
+    CONSTRAINT fk_user_id
+        FOREIGN KEY (user_id) 
+        REFERENCES user(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_program_id
+        FOREIGN KEY (program_id) 
+        REFERENCES program(id)
+        ON DELETE CASCADE,
+    PRIMARY KEY (user_id, program_id)
 );

--- a/server/db/schema/regional_director.sql
+++ b/server/db/schema/regional_director.sql
@@ -1,6 +1,11 @@
 CREATE TABLE IF NOT EXISTS regional_director (
-    user_id BIGSERIAL,
-    region_id SERIAL,
-    FOREIGN KEY (user_id) REFERENCES user(id),
-    FOREIGN KEY (region_id) REFERENCES region(id)
+    user_id BIGINT,
+    region_id INT,
+    CONSTRAINT fk_user_id        
+        FOREIGN KEY (user_id) REFERENCES user(id)
+        ON DELETE CASCADE,
+    CONSTRAINT fk_region_id
+        FOREIGN KEY (region_id) REFERENCES region(id)
+        ON DELETE CASCADE,
+    PRIMARY KEY (user_id, region_id)
 );

--- a/server/db/schema/user.sql
+++ b/server/db/schema/user.sql
@@ -7,5 +7,8 @@ CREATE TABLE IF NOT EXISTS user (
     first_name VARCHAR(70) NOT NULL,
     last_name VARCHAR(70) NOT NULL,
     date_created DATE NOT NULL,
-    created_by BIGSERIAL
+    created_by BIGINT,
+    CONSTRAINT fk_created_by
+        FOREIGN KEY (created_by) REFERENCES user(id)
+        ON DELETE SET NULL
 );


### PR DESCRIPTION
## Description

- Added regional_director.sql, program_director.sql, and user.sql files
- Created tables for each file according to Figma schema
- regional_director and program_director reference user's "id" key
- Tested insert and query on DBFiddle

## Screenshots/Media
<img width="535" height="526" alt="image" src="https://github.com/user-attachments/assets/ae5e7fd8-fdf9-4ce5-a339-e01ea2ca9bf5" />

- We created two dummy tables, program and region, for the keys referenced in regional_director and program_director.

<img width="515" height="248" alt="image" src="https://github.com/user-attachments/assets/4d00924e-75a5-4928-965b-bb3d0f5af3f8" />

- Our sample inserts to the tables.

<img width="228" height="106" alt="image" src="https://github.com/user-attachments/assets/56153a7b-8b78-42b1-acc8-8e4402a1d50d" />

- Our queries.

<img width="1675" height="391" alt="image" src="https://github.com/user-attachments/assets/7dac18f1-6003-4b4c-94ef-43fa4145fa1c" />

- The results display the 3 tables, including dummies. The primary keys are auto-incremented.

## Issues
Closes #8 

## Additional Notes
- In our tests, we had to rename the user table to "users". In the actual commit, the table is named "user"
- The schema lists "created_by" as a foreign key, but there's no table with created_by as a primary key, so we made created_by as another field.


