### PR TITLE
Spacing Fixes + Logo Redirects to Dashboard

### DIFF
--- a/client/src/components/dashboard/Dashboard.jsx
+++ b/client/src/components/dashboard/Dashboard.jsx
@@ -33,7 +33,7 @@ const Dashboard = () => {
       minH="100vh"
       gap={6}
       as="main"
-      p={10}
+      p={2}
       w="100%"
     >
       {!selectedPlaylist && (

--- a/client/src/components/navigation/Layout.jsx
+++ b/client/src/components/navigation/Layout.jsx
@@ -41,8 +41,8 @@ export const Layout = () => {
       minW={0}
       w="100%"
       maxW="100%"
-      padding={6}
-      gap={6}
+      padding={4}
+      gap={4}
       overflow="hidden"
     >
       <Sidebar />

--- a/client/src/components/navigation/Sidebar.jsx
+++ b/client/src/components/navigation/Sidebar.jsx
@@ -179,12 +179,17 @@ export const Sidebar = () => {
           justifyContent="center"
           flexShrink={0}
         >
-          <Image
-            src={logo}
-            alt={t('sidebar.logoAlt')}
-            objectFit="contain"
-            draggable={false}
-          />
+          <Link
+            as={RouterLink}
+            to="/dashboard"
+          >
+            <Image
+              src={logo}
+              alt={t('sidebar.logoAlt')}
+              objectFit="contain"
+              draggable={false}
+            />
+          </Link>
         </Box>
         <Flex
           direction="column"


### PR DESCRIPTION
## Description
- redirects back to dashboard (programs page) upon clicking GCF logo
- makes spacing tighter to match figma

## Screenshots/Media
<img width="3016" height="1644" alt="image" src="https://github.com/user-attachments/assets/3469af2d-8950-4b47-afa1-b38978ccbbdb" />

## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking the GCF logo now takes users back to the Programs dashboard for a consistent “home” action. Layout padding and gaps are tightened to match Figma for a cleaner, more compact view.

<sup>Written for commit 83b8a74edeb8de9e18319849e64542a4047b3c19. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

