### PR TITLE
Revert "Multiple Regional Directors for One Region - Regions Tab"

### DIFF
--- a/client/src/components/accounts/AccountForm/AccountFormDrawer.jsx
+++ b/client/src/components/accounts/AccountForm/AccountFormDrawer.jsx
@@ -1,0 +1,527 @@
+import {
+  Avatar,
+  Box,
+  Button,
+  Divider,
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerOverlay,
+  Flex,
+  FormControl,
+  FormLabel,
+  Grid,
+  GridItem,
+  Heading,
+  HStack,
+  IconButton,
+  Image,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Select,
+  Spacer,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+
+import { DirectorAvatar } from '@/components/dashboard/ProgramForm/DirectorAvatar';
+import { useTranslation } from 'react-i18next';
+import {
+  FiCamera,
+  FiEye,
+  FiEyeOff,
+  FiMaximize2,
+  FiMinimize2,
+  FiTrash2,
+} from 'react-icons/fi';
+
+import { DEFAULT_PROFILE_IMAGE, LABEL_COLOR } from './constants';
+
+export const AccountFormDrawer = ({
+  isOpen,
+  onClose,
+  isFullScreen,
+  onToggleFullScreen,
+  formData,
+  onChange,
+  errorBorderProps,
+  showPassword,
+  onToggleShowPassword,
+  targetUserId,
+  viewerRole,
+  currentPrograms,
+  currentRegions,
+  setFormData,
+  createdByName,
+  createdByPicture = '',
+  creatorPhotoUrl = '',
+  isNewAccount = false,
+  onDeleteClick,
+  onCancel,
+  onSave,
+  isLoading,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      placement="right"
+      onClose={onClose}
+      size="lg"
+    >
+      <DrawerOverlay />
+      <DrawerContent
+        w={isFullScreen ? '100vw' : '50vw'}
+        maxW={isFullScreen ? '100vw' : '50vw'}
+        display="flex"
+        flexDirection="column"
+      >
+        <Flex
+          align="center"
+          px={4}
+          pt={3}
+          pb={2}
+        >
+          <IconButton
+            icon={isFullScreen ? <FiMinimize2 /> : <FiMaximize2 />}
+            aria-label={
+              isFullScreen
+                ? t('fullscreenFlyout.minimize')
+                : t('fullscreenFlyout.expand')
+            }
+            variant="ghost"
+            size="sm"
+            onClick={onToggleFullScreen}
+          />
+          <Text
+            fontWeight="bold"
+            fontSize="xl"
+            flex={1}
+            textAlign="center"
+          >
+            {t('accountForm.drawerTitle')}
+          </Text>
+          <Box w="32px" />
+        </Flex>
+        <Divider borderColor="gray.300" />
+
+        <DrawerBody
+          flex={1}
+          overflowY="auto"
+          py={6}
+          px={8}
+        >
+          <VStack
+            spacing={6}
+            align="stretch"
+          >
+            <Heading
+              as="h3"
+              size="md"
+              fontWeight="semibold"
+            >
+              {t('accountForm.userProfile')}
+            </Heading>
+
+            <Box>
+              <Text
+                color={LABEL_COLOR}
+                fontSize="sm"
+                fontWeight="medium"
+                mb={3}
+              >
+                {t('accountForm.profilePhoto')}
+              </Text>
+              <Flex justify="center">
+                <Box
+                  position="relative"
+                  display="inline-block"
+                >
+                  <Image
+                    src={DEFAULT_PROFILE_IMAGE}
+                    boxSize="180px"
+                    borderRadius="full"
+                    fit="cover"
+                    alt={t('accountForm.profileAlt')}
+                    bg="gray.200"
+                    fallback={
+                      <Avatar
+                        size="2xl"
+                        name={
+                          formData.first_name || formData.last_name
+                            ? `${formData.first_name} ${formData.last_name}`
+                            : undefined
+                        }
+                        bg="gray.300"
+                        w="180px"
+                        h="180px"
+                      />
+                    }
+                  />
+                  <IconButton
+                    icon={<FiCamera />}
+                    aria-label={t('profile.uploadPhoto')}
+                    borderRadius="full"
+                    size="sm"
+                    bg="white"
+                    boxShadow="md"
+                    position="absolute"
+                    bottom={2}
+                    right={2}
+                    _hover={{ bg: 'gray.100' }}
+                  />
+                </Box>
+              </Flex>
+            </Box>
+
+            <Grid
+              templateColumns="repeat(2, 1fr)"
+              gap={4}
+            >
+              <GridItem>
+                <FormControl>
+                  <FormLabel
+                    color={LABEL_COLOR}
+                    fontSize="sm"
+                    fontWeight="medium"
+                  >
+                    {t('accountForm.fieldFirstName')}{' '}
+                    <Text
+                      as="span"
+                      color="red.500"
+                    >
+                      *
+                    </Text>
+                  </FormLabel>
+                  <Input
+                    name="first_name"
+                    placeholder={t('accountForm.fieldFirstName')}
+                    value={formData.first_name}
+                    onChange={onChange}
+                    {...errorBorderProps('first_name')}
+                  />
+                </FormControl>
+              </GridItem>
+              <GridItem>
+                <FormControl>
+                  <FormLabel
+                    color={LABEL_COLOR}
+                    fontSize="sm"
+                    fontWeight="medium"
+                  >
+                    {t('accountForm.fieldLastName')}{' '}
+                    <Text
+                      as="span"
+                      color="red.500"
+                    >
+                      *
+                    </Text>
+                  </FormLabel>
+                  <Input
+                    name="last_name"
+                    placeholder={t('accountForm.fieldLastName')}
+                    value={formData.last_name}
+                    onChange={onChange}
+                    {...errorBorderProps('last_name')}
+                  />
+                </FormControl>
+              </GridItem>
+            </Grid>
+
+            <Grid
+              templateColumns="repeat(2, 1fr)"
+              gap={4}
+            >
+              <GridItem>
+                <FormControl>
+                  <FormLabel
+                    color={LABEL_COLOR}
+                    fontSize="sm"
+                    fontWeight="medium"
+                  >
+                    {t('accountForm.fieldEmail')}{' '}
+                    <Text
+                      as="span"
+                      color="red.500"
+                    >
+                      *
+                    </Text>
+                  </FormLabel>
+                  <Input
+                    name="email"
+                    placeholder={t('accountForm.emailAddressPlaceholder')}
+                    value={formData.email}
+                    onChange={onChange}
+                    {...errorBorderProps('email')}
+                  />
+                </FormControl>
+              </GridItem>
+              {targetUserId ? (
+                <GridItem>
+                  <FormControl>
+                    <FormLabel
+                      color={LABEL_COLOR}
+                      fontSize="sm"
+                      fontWeight="medium"
+                    >
+                      {t('accountForm.fieldPassword')}
+                    </FormLabel>
+                    <InputGroup>
+                      <Input
+                        name="password"
+                        type={showPassword ? 'text' : 'password'}
+                        autoComplete="new-password"
+                        placeholder={t('accountForm.passwordLeaveBlank')}
+                        value={formData.password}
+                        onChange={onChange}
+                        {...errorBorderProps('password')}
+                      />
+                      <InputRightElement>
+                        <IconButton
+                          icon={showPassword ? <FiEye /> : <FiEyeOff />}
+                          aria-label={t('profile.togglePassword')}
+                          variant="ghost"
+                          size="sm"
+                          onClick={onToggleShowPassword}
+                        />
+                      </InputRightElement>
+                    </InputGroup>
+                  </FormControl>
+                </GridItem>
+              ) : (
+                <GridItem>
+                  <Text
+                    fontSize="sm"
+                    color="gray.600"
+                    pt={8}
+                  >
+                    {t('accountForm.passwordEmailNote')}
+                  </Text>
+                </GridItem>
+              )}
+            </Grid>
+
+            <Heading
+              as="h3"
+              size="md"
+              fontWeight="semibold"
+              mt={4}
+            >
+              {t('accountForm.roleAccess')}
+            </Heading>
+
+            <FormControl>
+              <FormLabel
+                color={LABEL_COLOR}
+                fontSize="sm"
+                fontWeight="medium"
+              >
+                {t('accountForm.fieldRole')}{' '}
+                <Text
+                  as="span"
+                  color="red.500"
+                >
+                  *
+                </Text>
+              </FormLabel>
+              <Select
+                name="role"
+                placeholder={t('accountForm.rolePlaceholder')}
+                value={formData.role}
+                onChange={onChange}
+                {...errorBorderProps('role')}
+              >
+                {viewerRole === 'Super Admin' && (
+                  <option value="Admin">{t('signup.roleAdmin')}</option>
+                )}
+                {(viewerRole === 'Admin' || viewerRole === 'Super Admin') && (
+                  <option value="Regional Director">
+                    {t('signup.roleRegionalDirector')}
+                  </option>
+                )}
+                <option value="Program Director">
+                  {t('signup.roleProgramDirector')}
+                </option>
+              </Select>
+            </FormControl>
+
+            {formData.role === 'Program Director' && (
+              <FormControl>
+                <FormLabel
+                  color={LABEL_COLOR}
+                  fontSize="sm"
+                  fontWeight="medium"
+                >
+                  {t('accountForm.assignedProgram')}
+                </FormLabel>
+                <Select
+                  placeholder={t('accountForm.programNamePlaceholder')}
+                  value={
+                    formData.programs.length > 0
+                      ? String(formData.programs[0].id)
+                      : ''
+                  }
+                  onChange={(e) => {
+                    const selectedProgramId = e.target.value;
+                    if (!selectedProgramId) return;
+
+                    const selectedProgram = currentPrograms?.find(
+                      (p) => String(p.id) === String(selectedProgramId)
+                    );
+
+                    if (selectedProgram) {
+                      setFormData((prev) => ({
+                        ...prev,
+                        programs: [selectedProgram],
+                      }));
+                    }
+                  }}
+                >
+                  {currentPrograms?.map((program) => (
+                    <option
+                      key={program.id}
+                      value={program.id}
+                    >
+                      {program.name}
+                    </option>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+            {formData.role === 'Regional Director' && (
+              <FormControl>
+                <FormLabel
+                  color={LABEL_COLOR}
+                  fontSize="sm"
+                  fontWeight="medium"
+                >
+                  {t('accountForm.assignedRegion')}
+                </FormLabel>
+                <Select
+                  placeholder={t('accountForm.regionNamePlaceholder')}
+                  value={
+                    formData.regions.length > 0
+                      ? String(formData.regions[0].id)
+                      : ''
+                  }
+                  onChange={(e) => {
+                    const selectedRegionId = e.target.value;
+                    if (!selectedRegionId) return;
+
+                    const selectedRegion = currentRegions?.find(
+                      (r) => String(r.id) === String(selectedRegionId)
+                    );
+
+                    if (selectedRegion) {
+                      setFormData((prev) => ({
+                        ...prev,
+                        regions: [selectedRegion],
+                      }));
+                    }
+                  }}
+                >
+                  {currentRegions?.map((region) => (
+                    <option
+                      key={region.id}
+                      value={region.id}
+                    >
+                      {region.name}
+                    </option>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+            {formData.role === 'Program Director' && (
+              <Heading
+                as="h3"
+                size="md"
+                fontWeight="semibold"
+                mt={4}
+              >
+                {t('accountForm.additionalInfo')}
+              </Heading>
+            )}
+
+            <Box mt={4}>
+              <Text
+                color={LABEL_COLOR}
+                fontSize="sm"
+                fontWeight="medium"
+                mb={2}
+              >
+                {t('accountForm.createdBy')}
+              </Text>
+              <HStack spacing={2}>
+                {isNewAccount ? (
+                  <Avatar
+                    size="sm"
+                    name={createdByName}
+                    src={creatorPhotoUrl || undefined}
+                    bg="teal.500"
+                    color="white"
+                  />
+                ) : createdByPicture ? (
+                  <DirectorAvatar
+                    picture={createdByPicture}
+                    name={createdByName}
+                    boxSize="32px"
+                  />
+                ) : (
+                  <Avatar
+                    size="sm"
+                    name={createdByName}
+                    bg="teal.500"
+                    color="white"
+                  />
+                )}
+                <Text fontSize="sm">{createdByName}</Text>
+              </HStack>
+            </Box>
+          </VStack>
+        </DrawerBody>
+
+        <Divider borderColor="gray.200" />
+        <Flex
+          align="center"
+          px={8}
+          py={4}
+          bg="white"
+        >
+          {targetUserId ? (
+            <Button
+              variant="ghost"
+              color="red.500"
+              leftIcon={<FiTrash2 />}
+              onClick={onDeleteClick}
+              fontWeight="normal"
+            >
+              {t('common.delete')}
+            </Button>
+          ) : null}
+          <Spacer />
+          <HStack spacing={3}>
+            <Button
+              variant="outline"
+              onClick={onCancel}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              bg="teal.500"
+              color="white"
+              _hover={{ bg: 'teal.600' }}
+              onClick={onSave}
+              isLoading={isLoading}
+            >
+              {t('common.save')}
+            </Button>
+          </HStack>
+        </Flex>
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/client/src/components/accounts/AccountForm/AccountFormModals.jsx
+++ b/client/src/components/accounts/AccountForm/AccountFormModals.jsx
@@ -1,0 +1,245 @@
+import {
+  Badge,
+  Box,
+  Button,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalOverlay,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { getRoleBadgeProps, LABEL_COLOR } from './constants';
+
+export const AccountFormExitModal = ({
+  isOpen,
+  onClose,
+  onExitWithoutSaving,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered
+    >
+      <ModalOverlay />
+      <ModalContent
+        py={6}
+        px={4}
+      >
+        <ModalBody textAlign="center">
+          <Text
+            fontWeight="bold"
+            fontSize="lg"
+            mb={2}
+          >
+            {t('accountForm.exitTitle')}
+          </Text>
+          <Text
+            color="gray.500"
+            mb={6}
+          >
+            {t('accountForm.exitDesc')}
+          </Text>
+          <HStack
+            spacing={3}
+            justify="center"
+          >
+            <Button
+              variant="outline"
+              onClick={onClose}
+            >
+              {t('common.continueEditing')}
+            </Button>
+            <Button
+              bg="red.500"
+              color="white"
+              _hover={{ bg: 'red.600' }}
+              onClick={onExitWithoutSaving}
+            >
+              {t('common.exitWithoutSaving')}
+            </Button>
+          </HStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export const AccountFormDeleteModal = ({
+  isOpen,
+  onClose,
+  onConfirmDelete,
+  isDeleting = false,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={isDeleting ? () => {} : onClose}
+      closeOnOverlayClick={!isDeleting}
+      isCentered
+    >
+      <ModalOverlay />
+      <ModalContent
+        py={6}
+        px={4}
+      >
+        <ModalBody textAlign="center">
+          <Text
+            fontWeight="bold"
+            fontSize="lg"
+            mb={2}
+          >
+            {t('accountForm.deleteTitle')}
+          </Text>
+          <Text
+            color="gray.500"
+            mb={6}
+          >
+            {t('accountForm.deleteDesc')}
+          </Text>
+          <HStack
+            spacing={3}
+            justify="center"
+          >
+            <Button
+              variant="outline"
+              onClick={onClose}
+              isDisabled={isDeleting}
+            >
+              {t('common.continueEditing')}
+            </Button>
+            <Button
+              bg="red.500"
+              color="white"
+              _hover={{ bg: 'red.600' }}
+              onClick={onConfirmDelete}
+              isLoading={isDeleting}
+            >
+              {t('accountForm.deleteAccount')}
+            </Button>
+          </HStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export const AccountFormSaveReviewModal = ({
+  isOpen,
+  onClose,
+  changedFields,
+  onConfirm,
+  isLoading,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      isCentered
+      size="lg"
+    >
+      <ModalOverlay />
+      <ModalContent
+        py={6}
+        px={6}
+      >
+        <ModalBody>
+          <Text
+            fontWeight="bold"
+            fontSize="lg"
+            color="teal.600"
+            mb={4}
+          >
+            {t('common.reviewChanges')}
+          </Text>
+
+          <VStack
+            spacing={3}
+            align="stretch"
+          >
+            {changedFields.map((change, idx) => (
+              <Box key={idx}>
+                <Text
+                  color={LABEL_COLOR}
+                  fontSize="sm"
+                  fontWeight="medium"
+                  mb={1}
+                >
+                  {change.label}
+                </Text>
+                {change.isBadge ? (
+                  <HStack spacing={2}>
+                    <Badge
+                      px={2}
+                      py={0.5}
+                      borderRadius="full"
+                      textDecoration="line-through"
+                      {...getRoleBadgeProps(change.old)}
+                    >
+                      {change.old}
+                    </Badge>
+                    <Badge
+                      px={2}
+                      py={0.5}
+                      borderRadius="full"
+                      {...getRoleBadgeProps(change.new)}
+                    >
+                      {change.new}
+                    </Badge>
+                  </HStack>
+                ) : (
+                  <Text>
+                    {change.old && (
+                      <Text
+                        as="span"
+                        textDecoration="line-through"
+                        color="gray.400"
+                        mr={2}
+                      >
+                        {change.old}
+                      </Text>
+                    )}
+                    <Text as="span">{change.new}</Text>
+                  </Text>
+                )}
+              </Box>
+            ))}
+          </VStack>
+
+          <HStack
+            spacing={3}
+            justify="center"
+            mt={6}
+          >
+            <Button
+              variant="outline"
+              onClick={onClose}
+            >
+              {t('common.continueEditing')}
+            </Button>
+            <Button
+              bg="teal.500"
+              color="white"
+              _hover={{ bg: 'teal.600' }}
+              onClick={onConfirm}
+              isLoading={isLoading}
+            >
+              {t('common.confirmChanges')}
+            </Button>
+          </HStack>
+        </ModalBody>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/client/src/components/accounts/AccountForm/changedFields.js
+++ b/client/src/components/accounts/AccountForm/changedFields.js
@@ -1,0 +1,65 @@
+export function computeChangedFields(formData, initialFormData, t) {
+  const mask = t('accountForm.passwordMaskStars');
+  const changes = [];
+  if (formData.first_name !== initialFormData.first_name) {
+    changes.push({
+      label: t('accountForm.fieldFirstName'),
+      old: initialFormData.first_name,
+      new: formData.first_name,
+    });
+  }
+  if (formData.last_name !== initialFormData.last_name) {
+    changes.push({
+      label: t('accountForm.fieldLastName'),
+      old: initialFormData.last_name,
+      new: formData.last_name,
+    });
+  }
+  if (formData.email !== initialFormData.email) {
+    changes.push({
+      label: t('accountForm.fieldEmail'),
+      old: initialFormData.email,
+      new: formData.email,
+    });
+  }
+  if (formData.password && formData.password !== initialFormData.password) {
+    changes.push({
+      label: t('accountForm.fieldPassword'),
+      old: initialFormData.password || mask,
+      new: mask,
+    });
+  }
+  if (formData.role !== initialFormData.role) {
+    changes.push({
+      label: t('accountForm.fieldRole'),
+      old: initialFormData.role,
+      new: formData.role,
+      isBadge: true,
+    });
+  }
+  const oldProgram =
+    initialFormData.programs.length > 0
+      ? initialFormData.programs[0]?.name
+      : '';
+  const newProgram =
+    formData.programs.length > 0 ? formData.programs[0]?.name : '';
+  if (oldProgram !== newProgram) {
+    changes.push({
+      label: t('accountForm.fieldProgram'),
+      old: oldProgram || '',
+      new: newProgram || '',
+    });
+  }
+  const oldRegion =
+    initialFormData.regions.length > 0 ? initialFormData.regions[0]?.name : '';
+  const newRegion =
+    formData.regions.length > 0 ? formData.regions[0]?.name : '';
+  if (oldRegion !== newRegion) {
+    changes.push({
+      label: t('accountForm.fieldRegion'),
+      old: oldRegion || '',
+      new: newRegion || '',
+    });
+  }
+  return changes;
+}

--- a/client/src/components/accounts/AccountForm/constants.js
+++ b/client/src/components/accounts/AccountForm/constants.js
@@ -1,0 +1,41 @@
+export const DEFAULT_PROFILE_IMAGE = '/default-profile.png';
+export const LABEL_COLOR = 'teal.600';
+
+export const getRoleBadgeProps = (roleName) => {
+  switch (roleName) {
+    case 'Program Director':
+      return { bg: 'teal.100', color: 'teal.800' };
+    case 'Regional Director':
+      return { bg: 'teal.400', color: 'white' };
+    case 'Admin':
+    case 'Super Admin':
+      return { bg: 'teal.700', color: 'white' };
+    default:
+      return { bg: 'gray.200', color: 'gray.800' };
+  }
+};
+
+export const INITIAL_FORM_STATE = {
+  first_name: '',
+  last_name: '',
+  role: '',
+  email: '',
+  password: '',
+  programs: [],
+  regions: [],
+};
+
+export const formStateToAuditSnapshot = (fd, meta = {}) => ({
+  email: fd.email,
+  firstName: fd.first_name,
+  lastName: fd.last_name,
+  role: fd.role,
+  programId: fd.programs?.length > 0 ? Number(fd.programs[0].id) : null,
+  regionId: fd.regions?.length > 0 ? Number(fd.regions[0].id) : null,
+  ...(meta.currentUserId !== undefined && meta.currentUserId !== null
+    ? { currentUserId: meta.currentUserId }
+    : {}),
+  ...(meta.targetId !== undefined && meta.targetId !== null
+    ? { targetId: meta.targetId }
+    : {}),
+});

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -1,0 +1,499 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { useDisclosure, useToast } from '@chakra-ui/react';
+
+import { useAuthContext } from '@/contexts/hooks/useAuthContext';
+import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { useRoleContext } from '@/contexts/hooks/useRoleContext';
+import { getAuth, sendPasswordResetEmail } from 'firebase/auth';
+import { useTranslation } from 'react-i18next';
+
+import { AccountFormDrawer } from './AccountFormDrawer';
+import {
+  AccountFormDeleteModal,
+  AccountFormExitModal,
+  AccountFormSaveReviewModal,
+} from './AccountFormModals';
+import { computeChangedFields } from './changedFields';
+import { formStateToAuditSnapshot, INITIAL_FORM_STATE } from './constants';
+
+export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
+  const { t } = useTranslation();
+  const { currentUser } = useAuthContext();
+  const { backend } = useBackendContext();
+  const { role } = useRoleContext();
+  const userId = currentUser?.uid;
+  const targetUserId = targetUser?.id;
+
+  const [isFullScreen, setIsFullScreen] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [validationErrors, setValidationErrors] = useState({});
+  const [currentPrograms, setCurrentPrograms] = useState(null);
+  const [currentRegions, setCurrentRegions] = useState(null);
+
+  const exitModal = useDisclosure();
+  const deleteModal = useDisclosure();
+  const saveModal = useDisclosure();
+  const auth = getAuth();
+  const toast = useToast();
+  const [formData, setFormData] = useState({ ...INITIAL_FORM_STATE });
+  const [initialFormData, setInitialFormData] = useState({
+    ...INITIAL_FORM_STATE,
+  });
+
+  const isDirty = useMemo(() => {
+    return JSON.stringify(formData) !== JSON.stringify(initialFormData);
+  }, [formData, initialFormData]);
+
+  const changedFields = useMemo(
+    () => computeChangedFields(formData, initialFormData, t),
+    [formData, initialFormData, t]
+  );
+
+  // Reset form when drawer opens
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setValidationErrors({});
+    setShowPassword(false);
+    setIsFullScreen(false);
+
+    if (!targetUser) {
+      const newState = { ...INITIAL_FORM_STATE, programs: [], regions: [] };
+      setFormData(newState);
+      setInitialFormData(newState);
+    } else {
+      const editState = {
+        first_name: targetUser.firstName ?? '',
+        last_name: targetUser.lastName ?? '',
+        role: targetUser.role ?? '',
+        email: targetUser.email ?? '',
+        password: '',
+        programs: [],
+        regions: [],
+      };
+      setFormData(editState);
+      setInitialFormData(editState);
+
+      if (!targetUser.email && targetUserId) {
+        const fetchEmail = async () => {
+          try {
+            const response = await backend.get(
+              `/gcf-users/admin/get-user/${targetUserId}`
+            );
+            const email = response.data.email ?? '';
+            setFormData((prev) => ({ ...prev, email }));
+            setInitialFormData((prev) => ({ ...prev, email }));
+          } catch (error) {
+            console.error('Error loading target user email', error);
+          }
+        };
+        fetchEmail();
+      }
+    }
+  }, [targetUser, targetUserId, backend, isOpen]);
+
+  // Fetch programs and regions
+  useEffect(() => {
+    async function fetchPrograms() {
+      try {
+        let response;
+        if (role === 'Regional Director') {
+          response = await backend.get(
+            `/regional-directors/me/${userId}/programs`
+          );
+        } else {
+          response = await backend.get('/program');
+        }
+        setCurrentPrograms(response.data);
+      } catch (error) {
+        console.error('Error fetching programs', error);
+      }
+    }
+
+    async function fetchRegions() {
+      try {
+        const response = await backend.get('/region');
+        setCurrentRegions(response.data);
+      } catch (error) {
+        console.error('Error fetching regions', error);
+      }
+    }
+
+    if (role && userId) {
+      fetchPrograms();
+      fetchRegions();
+    }
+  }, [backend, role, userId]);
+
+  useEffect(() => {
+    if (!targetUserId || !targetUser) return;
+
+    if (targetUser.role === 'Program Director') {
+      const fetchUserPrograms = async () => {
+        try {
+          const response = await backend.get(
+            `/program-directors/me/${targetUserId}/program`
+          );
+          const program = response.data;
+          setFormData((prev) => ({ ...prev, programs: [program] }));
+          setInitialFormData((prev) => ({ ...prev, programs: [program] }));
+        } catch (error) {
+          console.error("Error fetching user's programs:", error);
+        }
+      };
+      fetchUserPrograms();
+    }
+
+    if (targetUser.role === 'Regional Director') {
+      const fetchUserRegion = async () => {
+        try {
+          const response = await backend.get(
+            `/regional-directors/me/${targetUserId}`
+          );
+          const regionId = response.data.regionId;
+
+          if (regionId && currentRegions) {
+            const region = currentRegions.find(
+              (r) => String(r.id) === String(regionId)
+            );
+            setFormData((prev) => ({
+              ...prev,
+              regions: region ? [region] : [],
+            }));
+            setInitialFormData((prev) => ({
+              ...prev,
+              regions: region ? [region] : [],
+            }));
+          }
+        } catch (error) {
+          console.error("Error fetching user's region:", error);
+        }
+      };
+      fetchUserRegion();
+    }
+  }, [backend, targetUserId, targetUser, currentRegions]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+    if (validationErrors[name]) {
+      setValidationErrors((prev) => ({ ...prev, [name]: false }));
+    }
+  };
+
+  const validate = () => {
+    const errors = {};
+    if (!formData.first_name.trim()) errors.first_name = true;
+    if (!formData.last_name.trim()) errors.last_name = true;
+    if (!formData.email.trim()) errors.email = true;
+    if (!formData.role) errors.role = true;
+    setValidationErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
+  const handleSaveClick = () => {
+    if (!validate()) return;
+
+    if (targetUserId && isDirty) {
+      saveModal.onOpen();
+    } else {
+      handleSubmit();
+    }
+  };
+
+  const handleSubmit = async () => {
+    setIsLoading(true);
+    saveModal.onClose();
+
+    try {
+      if (!targetUserId) {
+        await handleCreateUser();
+      } else {
+        await handleUpdateUser();
+      }
+      toast({
+        title: t('accountForm.saveSuccess'),
+        status: 'success',
+        duration: 3000,
+        isClosable: true,
+      });
+      onSave();
+      onClose();
+    } catch (error) {
+      console.error('Error saving user: ', error);
+      const errorMessage = error.response?.data?.error || error.message;
+
+      if (
+        errorMessage.includes('email-already-exists') ||
+        errorMessage.includes('email address is already in use')
+      ) {
+        toast({
+          title: t('accountForm.emailExistsTitle'),
+          description: t('accountForm.emailExistsDesc'),
+          status: 'error',
+          duration: 3000,
+          isClosable: true,
+        });
+      } else {
+        toast({
+          title: t('accountForm.errorTitle'),
+          description: t('accountForm.errorWithMessage', {
+            message: errorMessage,
+          }),
+          status: 'error',
+          duration: 3000,
+          isClosable: true,
+        });
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const logAccountChange = async (payload) => {
+    try {
+      await backend.post('/accountChange', payload);
+    } catch (err) {
+      console.error('Failed to log account change:', err);
+    }
+  };
+
+  const handleCreateUser = async () => {
+    if (
+      !formData.first_name ||
+      !formData.last_name ||
+      !formData.role ||
+      !formData.email
+    ) {
+      throw new Error(t('accountForm.fillAllFields'));
+    }
+
+    const userData = {
+      email: formData.email,
+      firstName: formData.first_name,
+      lastName: formData.last_name,
+      role: formData.role,
+      currentUserId: userId,
+      programId:
+        formData.programs.length > 0 ? Number(formData.programs[0].id) : null,
+      regionId:
+        formData.regions.length > 0 ? Number(formData.regions[0].id) : null,
+    };
+    const createRes = await backend.post(
+      '/gcf-users/admin/create-user',
+      userData
+    );
+    const newUserId = createRes.data?.uid;
+    if (newUserId && userId) {
+      await logAccountChange({
+        user_id: String(newUserId),
+        author_id: String(userId),
+        change_type: 'Creation',
+        old_values: null,
+        new_values: userData,
+        resolved: true,
+        last_modified: new Date().toISOString(),
+      });
+    }
+    await sendPasswordResetEmail(auth, formData.email);
+  };
+
+  const handleUpdateUser = async () => {
+    if (
+      !formData.first_name ||
+      !formData.last_name ||
+      !formData.role ||
+      !formData.email
+    ) {
+      throw new Error(t('accountForm.fillAllFields'));
+    }
+    const userData = {
+      email: formData.email,
+      firstName: formData.first_name,
+      lastName: formData.last_name,
+      role: formData.role,
+      currentUserId: userId,
+      targetId: targetUserId,
+      programId:
+        formData.programs.length > 0 ? Number(formData.programs[0].id) : null,
+      regionId:
+        formData.regions.length > 0 ? Number(formData.regions[0].id) : null,
+    };
+
+    if (formData.password && formData.password.trim().length > 0) {
+      userData.password = formData.password;
+    }
+    await backend.put('/gcf-users/admin/update-user', userData);
+
+    if (userId) {
+      await logAccountChange({
+        user_id: String(targetUserId),
+        author_id: String(userId),
+        change_type: 'Update',
+        old_values: formStateToAuditSnapshot(initialFormData, {
+          currentUserId: userId,
+          targetId: targetUserId,
+        }),
+        new_values: formStateToAuditSnapshot(formData, {
+          currentUserId: userId,
+          targetId: targetUserId,
+        }),
+        resolved: true,
+        last_modified: new Date().toISOString(),
+      });
+    }
+  };
+
+  const handleCloseWithCheck = () => {
+    if (isDirty) {
+      exitModal.onOpen();
+    } else {
+      onClose();
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!targetUserId) return;
+
+    setIsDeleting(true);
+    try {
+      if (userId) {
+        await logAccountChange({
+          user_id: String(targetUserId),
+          author_id: String(userId),
+          change_type: 'Deletion',
+          old_values: formStateToAuditSnapshot(initialFormData, {
+            currentUserId: userId,
+            targetId: targetUserId,
+          }),
+          new_values: null,
+          resolved: true,
+          last_modified: new Date().toISOString(),
+        });
+      }
+      try {
+        await backend.delete(`/gcf-users/${targetUserId}`);
+        toast({
+          title: t('accountForm.deleteSuccess', {
+            defaultValue: 'Account deleted',
+          }),
+          status: 'success',
+          duration: 3000,
+          isClosable: true,
+        });
+      } catch (deleteErr) {
+        const status = deleteErr.response?.status;
+        const data = deleteErr.response?.data;
+        if (status === 503 && data?.gcfUserDeleted) {
+          toast({
+            title: t('accountForm.deletePartialTitle', {
+              defaultValue: 'Account removed from directory',
+            }),
+            description: t('accountForm.deletePartialDesc', {
+              defaultValue:
+                'The user was removed from the app, but their sign-in account could not be deleted automatically. You may need to remove it from Firebase or try again later.',
+            }),
+            status: 'warning',
+            duration: 8000,
+            isClosable: true,
+          });
+        } else {
+          throw deleteErr;
+        }
+      }
+      deleteModal.onClose();
+      onSave();
+      onClose();
+    } catch (error) {
+      console.error('Error deleting user:', error);
+      const errorMessage = error.response?.data?.error || error.message;
+      toast({
+        title: t('accountForm.errorTitle'),
+        description: t('accountForm.errorWithMessage', {
+          message: errorMessage,
+        }),
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // "Created by" is the account record's creator when editing; when creating a new
+  // user it is the current admin (the creator that will be stored on save).
+  const isNewAccount = !targetUserId;
+  const createdByName = isNewAccount
+    ? currentUser?.displayName ||
+      `${currentUser?.email?.split('@')[0] || t('common.unknownUser')}`
+    : targetUser?.createdBy?.trim() || t('common.emDash');
+  const createdByPicture = isNewAccount
+    ? ''
+    : targetUser?.createdByPicture || '';
+  const creatorPhotoUrl = isNewAccount ? currentUser?.photoURL || '' : '';
+
+  const errorBorderProps = (field) =>
+    validationErrors[field]
+      ? {
+          borderColor: 'red.500',
+          boxShadow: '0 0 0 1px var(--chakra-colors-red-500)',
+        }
+      : {};
+
+  return (
+    <>
+      <AccountFormDrawer
+        isOpen={isOpen}
+        onClose={handleCloseWithCheck}
+        isFullScreen={isFullScreen}
+        onToggleFullScreen={() => setIsFullScreen(!isFullScreen)}
+        formData={formData}
+        onChange={handleChange}
+        errorBorderProps={errorBorderProps}
+        showPassword={showPassword}
+        onToggleShowPassword={() => setShowPassword(!showPassword)}
+        targetUserId={targetUserId}
+        viewerRole={role}
+        currentPrograms={currentPrograms}
+        currentRegions={currentRegions}
+        setFormData={setFormData}
+        createdByName={createdByName}
+        createdByPicture={createdByPicture}
+        creatorPhotoUrl={creatorPhotoUrl}
+        isNewAccount={isNewAccount}
+        onDeleteClick={() => deleteModal.onOpen()}
+        onCancel={handleCloseWithCheck}
+        onSave={handleSaveClick}
+        isLoading={isLoading}
+      />
+
+      <AccountFormExitModal
+        isOpen={exitModal.isOpen}
+        onClose={exitModal.onClose}
+        onExitWithoutSaving={() => {
+          exitModal.onClose();
+          onClose();
+        }}
+      />
+
+      <AccountFormDeleteModal
+        isOpen={deleteModal.isOpen}
+        onClose={deleteModal.onClose}
+        onConfirmDelete={confirmDelete}
+        isDeleting={isDeleting}
+      />
+
+      <AccountFormSaveReviewModal
+        isOpen={saveModal.isOpen}
+        onClose={saveModal.onClose}
+        changedFields={changedFields}
+        onConfirm={handleSubmit}
+        isLoading={isLoading}
+      />
+    </>
+  );
+};

--- a/client/src/components/dashboard/FileUpload.jsx
+++ b/client/src/components/dashboard/FileUpload.jsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+import { useAuthContext } from '@/contexts/hooks/useAuthContext';
+import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+
+import { MediaGrid } from '../media/MediaGrid';
+
+const PDF = () => {
+  const { currentUser } = useAuthContext();
+  const userId = currentUser?.uid;
+  const { backend } = useBackendContext();
+  const [pdfs, setPdfs] = useState([]);
+  const [programName, setProgramName] = useState('');
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const fetchPdfs = async () => {
+      console.log('userId:', userId);
+      console.log('url:', `/fileChanges/${userId}/files`);
+      try {
+        const res = await backend.get(`/fileChanges/${userId}/files`);
+
+        if (!res) return;
+
+        const transformedFiles = await Promise.all(
+          res.data.files.map(async (file) => {
+            const urlResponse = await backend.get(
+              `/images/url/${encodeURIComponent(file.s3Key)}`
+            );
+
+            if (!urlResponse) return;
+
+            return {
+              id: file.id,
+              s3_key: file.s3Key,
+              file_name: file.fileName,
+              file_type: file.fileType,
+              imageUrl: urlResponse.data.url,
+            };
+          })
+        );
+
+        setPdfs(transformedFiles);
+        setProgramName(res.data.programName);
+      } catch (err) {
+        console.error('Error fetching PDFs:', err);
+      }
+    };
+
+    fetchPdfs();
+  }, [userId, backend]);
+
+  return (
+    <MediaGrid
+      mediaItems={pdfs}
+      programName={programName}
+    />
+  );
+};
+
+export default PDF;

--- a/client/src/components/dashboard/ProgramForm/ProgramFormMediaTab.jsx
+++ b/client/src/components/dashboard/ProgramForm/ProgramFormMediaTab.jsx
@@ -1,0 +1,53 @@
+import { Button, Heading, HStack, VStack } from '@chakra-ui/react';
+
+import { useTranslation } from 'react-i18next';
+
+import { MediaPreviewTag } from './MediaPreviewTag';
+import { removeFormItemByIdOrKey } from './programFormHelpers';
+
+export function ProgramFormMediaTab({
+  formState,
+  setFormState,
+  onOpenMediaUpload,
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <VStack
+      align="stretch"
+      spacing={4}
+    >
+      <Heading
+        size="md"
+        fontWeight="semibold"
+      >
+        {t('programForm.mediaHeading')}
+      </Heading>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={onOpenMediaUpload}
+      >
+        {t('common.add')}
+      </Button>
+      <HStack
+        wrap="wrap"
+        spacing={3}
+      >
+        {(formState.media ?? []).map((item, index) => (
+          <MediaPreviewTag
+            key={item.id || item.s3_key || `media-${index}`}
+            item={item}
+            onRemove={() => {
+              setFormState((prev) => ({
+                ...prev,
+                media: removeFormItemByIdOrKey(prev.media, item),
+              }));
+            }}
+            isMedia={true}
+          />
+        ))}
+      </HStack>
+    </VStack>
+  );
+}

--- a/client/src/components/dashboard/ProgramForm/ProgramFormOverviewTab.jsx
+++ b/client/src/components/dashboard/ProgramForm/ProgramFormOverviewTab.jsx
@@ -1,0 +1,154 @@
+import {
+  Box,
+  Checkbox,
+  FormControl,
+  FormLabel,
+  Heading,
+  Input,
+  Select,
+  VStack,
+} from '@chakra-ui/react';
+
+import { PartnerOrganizationField } from '@/components/partners/PartnerOrganizationField';
+import { useTranslation } from 'react-i18next';
+
+import { AssignedDirectorsSection } from './AssignedDirectorsSection';
+import { LocationLanguageSection } from './LocationLanguageSection';
+import { ResourcesSection } from './ResourcesSection';
+import { StudentsInstrumentsSection } from './StudentsInstrumentsSection';
+
+export function ProgramFormOverviewTab({
+  formState,
+  setFormState,
+  languageOptions,
+  onProgramNameChange,
+  onProgramStatusChange,
+  onProgramLaunchDateChange,
+  onLanguageChange,
+  programId,
+  backend,
+  onOpenMediaModal,
+  onSeeAllMedia,
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <Box>
+        <Heading
+          size="md"
+          fontWeight="semibold"
+          mb={3}
+        >
+          {t('programForm.generalInformation')}
+        </Heading>
+        <VStack
+          align="stretch"
+          spacing={4}
+        >
+          <FormControl isRequired>
+            <FormLabel
+              size="sm"
+              fontWeight="normal"
+              color="gray"
+            >
+              {t('programForm.programName')}
+            </FormLabel>
+            <Input
+              placeholder={t('programForm.enterProgramTitle')}
+              value={formState.programName || ''}
+              onChange={(e) => onProgramNameChange(e.target.value)}
+            />
+          </FormControl>
+
+          <PartnerOrganizationField
+            label={t('programForm.partnerOrgName')}
+            valueId={formState.partnerOrg}
+            onChangeId={(id) =>
+              setFormState((prev) => ({
+                ...prev,
+                partnerOrg: id,
+              }))
+            }
+          />
+
+          <FormControl>
+            <Checkbox
+              isChecked={Boolean(formState.showPartnerOrgOnMap)}
+              onChange={(e) =>
+                setFormState((prev) => ({
+                  ...prev,
+                  showPartnerOrgOnMap: e.target.checked,
+                }))
+              }
+            >
+              {t('programForm.showPartnerOnMap')}
+            </Checkbox>
+            {/* TODO: Implement persistence and map behavior for showPartnerOrgOnMap (API + map layer). */}
+          </FormControl>
+
+          <FormControl isRequired>
+            <FormLabel
+              size="sm"
+              fontWeight="normal"
+              color="gray"
+            >
+              {t('programForm.status')}
+            </FormLabel>
+            <Select
+              value={formState.status ?? ''}
+              onChange={(e) => onProgramStatusChange(e.target.value)}
+              placeholder={t('programForm.selectStatus')}
+            >
+              <option value="Active">{t('programForm.launched')}</option>
+              <option value="Inactive">{t('programForm.developing')}</option>
+            </Select>
+          </FormControl>
+
+          <FormControl>
+            <FormLabel
+              size="sm"
+              fontWeight="normal"
+              color="gray"
+            >
+              {t('programForm.launchDate')}
+            </FormLabel>
+            <Input
+              type="date"
+              placeholder={t('programForm.datePlaceholder')}
+              value={formState.launchDate || ''}
+              onChange={(e) => onProgramLaunchDateChange(e.target.value)}
+            />
+          </FormControl>
+        </VStack>
+      </Box>
+
+      <LocationLanguageSection
+        formState={formState}
+        setFormData={setFormState}
+        languageOptions={languageOptions}
+        onLanguagesChange={onLanguageChange}
+      />
+
+      <StudentsInstrumentsSection
+        formState={formState}
+        setFormData={setFormState}
+      />
+
+      <AssignedDirectorsSection
+        regionId={formState.regionId}
+        formState={formState}
+        setFormData={setFormState}
+      />
+
+      <ResourcesSection
+        formState={formState}
+        setFormData={setFormState}
+        programId={programId}
+        backend={backend}
+        onOpenMediaModal={onOpenMediaModal}
+        onSeeAllMedia={onSeeAllMedia}
+      />
+    </>
+  );
+}

--- a/client/src/components/dashboard/ProgramForm/programFormHelpers.js
+++ b/client/src/components/dashboard/ProgramForm/programFormHelpers.js
@@ -1,0 +1,45 @@
+/** Deletes instrument_change rows for this program + instrument (same as ProgramUpdateForm). */
+export async function deleteInstrumentChangesForProgramInstrument(
+  backend,
+  programId,
+  instrumentId
+) {
+  const numericProgramId = Number(programId);
+  const numericInstrumentId = Number(instrumentId);
+  if (Number.isNaN(numericInstrumentId)) return;
+
+  const res = await backend.get('/program-updates');
+  const updates = Array.isArray(res.data) ? res.data : [];
+  const updateIds = updates
+    .filter((u) => Number(u.programId ?? u.program_id) === numericProgramId)
+    .map((u) => u.id);
+
+  for (const updateId of updateIds) {
+    const icRes = await backend.get(`/instrument-changes/update/${updateId}`);
+    const rows = Array.isArray(icRes.data) ? icRes.data : [];
+    for (const row of rows) {
+      const iid = Number(row.instrumentId ?? row.instrument_id);
+      if (
+        iid === numericInstrumentId &&
+        row.id !== null &&
+        row.id !== undefined
+      ) {
+        await backend.delete(`/instrument-changes/${row.id}`);
+      }
+    }
+  }
+}
+
+export function removeFormItemByIdOrKey(list, item) {
+  return (list ?? []).filter((m) => {
+    const itemHasId = item.id !== null && item.id !== undefined;
+    const mHasId = m.id !== null && m.id !== undefined;
+    if (itemHasId && mHasId) return Number(m.id) !== Number(item.id);
+    if (item.s3_key && m.s3_key) return m.s3_key !== item.s3_key;
+    return m !== item;
+  });
+}
+
+export function isPdfByType(media) {
+  return media.file_type === 'application/pdf';
+}

--- a/client/src/components/dashboard/ProgramForm/programFormSave.js
+++ b/client/src/components/dashboard/ProgramForm/programFormSave.js
@@ -1,0 +1,263 @@
+import { deleteInstrumentChangesForProgramInstrument } from './programFormHelpers';
+
+export async function saveProgramForm({
+  backend,
+  currentUser,
+  program,
+  formState,
+  initialProgramDirectorIds,
+  setInitialProgramDirectorIds,
+  initialInstrumentQuantities,
+  initialCurriculumLinks,
+  initialGraduated,
+  onSave,
+  onClose,
+}) {
+  const rawPartner = formState.partnerOrg;
+  const hasPartnerOrg =
+    rawPartner !== null && rawPartner !== undefined && rawPartner !== '';
+  const partnerOrgPayload = hasPartnerOrg
+    ? Number(rawPartner)
+    : program
+      ? null
+      : 1;
+
+  const data = {
+    name: formState.programName,
+    title: formState.programName,
+    status: formState.status,
+    launchDate: formState.launchDate,
+    country: formState.country,
+    state: formState.state,
+    city: formState.city,
+    students: formState.students ?? 0,
+    languages: formState.languages ?? [],
+    partnerOrg: partnerOrgPayload,
+    createdBy: currentUser?.uid || currentUser?.id,
+    description: '',
+  };
+
+  let programId;
+  const oldStudentCount = program?.students || 0;
+  const deltaNet = (formState.students ?? 0) - oldStudentCount;
+  const deltaGrad = (formState.graduatedStudents ?? 0) - initialGraduated;
+  const enrollmentDelta = deltaNet + deltaGrad;
+  const graduatedDelta = deltaGrad;
+
+  if (program) {
+    await backend.put(`/program/${program.id}`, data);
+    programId = program.id;
+  } else {
+    const response = await backend.post(`/program`, data);
+    programId = response.data.id;
+  }
+
+  const selectedDirector = formState.programDirectors[0];
+  const selectedRaw = selectedDirector?.userId;
+  const selectedKey =
+    selectedRaw !== null &&
+    selectedRaw !== undefined &&
+    String(selectedRaw).trim() !== ''
+      ? String(selectedRaw).trim()
+      : '';
+  const validSelected = selectedKey !== '';
+
+  const initialIds = initialProgramDirectorIds || [];
+  const initialKeySet = new Set(
+    initialIds.map((id) =>
+      id !== null && id !== undefined ? String(id).trim() : ''
+    )
+  );
+
+  if (validSelected) {
+    for (const uid of initialIds) {
+      if (String(uid).trim() === selectedKey) continue;
+      await backend.delete(
+        `/program-directors/${encodeURIComponent(String(uid))}`,
+        {
+          params: { programId },
+        }
+      );
+    }
+    if (!initialKeySet.has(selectedKey)) {
+      await backend.post(`/program-directors`, {
+        userId: selectedRaw,
+        programId,
+      });
+    }
+    setInitialProgramDirectorIds([selectedRaw]);
+  } else {
+    for (const uid of initialIds) {
+      await backend.delete(
+        `/program-directors/${encodeURIComponent(String(uid))}`,
+        {
+          params: { programId },
+        }
+      );
+    }
+    setInitialProgramDirectorIds([]);
+  }
+
+  const currentLinkKeys = (formState.curriculumLinks ?? []).map(
+    (p) => `${p.link}\0${p.instrumentId}`
+  );
+  for (const playlist of formState.curriculumLinks ?? []) {
+    const key = `${playlist.link}\0${playlist.instrumentId}`;
+    if (
+      !initialCurriculumLinks.some(
+        (i) => `${i.link}\0${i.instrumentId}` === key
+      )
+    ) {
+      await backend.post(`/program/${programId}/playlists`, {
+        link: playlist.link,
+        name: playlist.name || 'Playlist',
+        instrumentId: playlist.instrumentId,
+      });
+    }
+  }
+  for (const old of initialCurriculumLinks) {
+    if (!currentLinkKeys.includes(`${old.link}\0${old.instrumentId}`)) {
+      await backend.delete(`/program/${programId}/playlists`, {
+        data: { link: old.link, instrumentId: old.instrumentId },
+      });
+    }
+  }
+
+  const currentMediaIds = formState.media
+    .map((m) => m.id)
+    .filter((id) => id !== undefined && id !== null);
+  const currentFileIds = formState.fileChanges
+    .map((f) => f.id)
+    .filter((id) => id !== undefined && id !== null);
+
+  const pendingMedia = formState.media.filter((m) => !m.id);
+  const pendingFiles = formState.fileChanges.filter((f) => !f.id);
+
+  if (program) {
+    const programMedia = program?.media ?? [];
+    const mediaToDelete = programMedia.filter(
+      (oldMedia) =>
+        oldMedia.id !== null &&
+        oldMedia.id !== undefined &&
+        !currentMediaIds.includes(oldMedia.id)
+    );
+
+    for (const media of mediaToDelete) {
+      if (media.id) {
+        await backend.delete(`/mediaChange/${media.id}`);
+      }
+    }
+
+    const programFiles = program?.fileChanges ?? [];
+    const filesToDelete = programFiles.filter(
+      (oldFile) =>
+        oldFile.id !== null &&
+        oldFile.id !== undefined &&
+        !currentFileIds.includes(oldFile.id)
+    );
+
+    for (const file of filesToDelete) {
+      if (file.id) {
+        await backend.delete(`/fileChanges/${file.id}`);
+      }
+    }
+  }
+
+  const instrumentChanges = [];
+  const instrumentIdsToPurge = [];
+
+  const allInstrumentIds = new Set([
+    ...Object.keys(initialInstrumentQuantities || {}),
+    ...Object.keys(formState.instruments || {}),
+  ]);
+
+  for (const id of allInstrumentIds) {
+    const newQty = formState.instruments?.[id]?.quantity ?? 0;
+    const oldQty = initialInstrumentQuantities?.[id] ?? 0;
+    if (program && newQty === 0 && oldQty > 0) {
+      instrumentIdsToPurge.push(Number(id));
+      continue;
+    }
+    const instrumentDiff = newQty - oldQty;
+    if (instrumentDiff !== 0) {
+      instrumentChanges.push({
+        instrumentId: Number(id),
+        amountChanged: instrumentDiff,
+      });
+    }
+  }
+
+  if (program && instrumentIdsToPurge.length > 0) {
+    for (const instId of instrumentIdsToPurge) {
+      await deleteInstrumentChangesForProgramInstrument(
+        backend,
+        programId,
+        instId
+      );
+    }
+  }
+
+  const hasStudentChange = enrollmentDelta !== 0 || graduatedDelta !== 0;
+  const hasInstrumentChange = instrumentChanges.length > 0;
+  const hasMediaChange = pendingMedia.length > 0 || pendingFiles.length > 0;
+
+  const isNewProgram = !program;
+
+  if (
+    isNewProgram ||
+    hasStudentChange ||
+    hasInstrumentChange ||
+    hasMediaChange
+  ) {
+    const updateResponse = await backend.post(`/program-updates`, {
+      title: isNewProgram ? 'Program Created' : 'update program stats',
+      program_id: programId,
+      created_by: currentUser?.uid || currentUser?.id,
+      update_date: new Date().toISOString(),
+      note: isNewProgram ? 'Program Created' : 'Program update',
+      show_on_table: isNewProgram,
+    });
+
+    const updateId = updateResponse.data.id;
+    if (hasStudentChange) {
+      await backend.post(`/enrollmentChange`, {
+        update_id: updateId,
+        enrollment_change: enrollmentDelta,
+        graduated_change: graduatedDelta,
+        event_type: 'other',
+      });
+    }
+    if (hasInstrumentChange) {
+      for (const instrumentChange of instrumentChanges) {
+        await backend.post(`/instrument-changes`, {
+          instrumentId: instrumentChange.instrumentId,
+          updateId,
+          amountChanged: instrumentChange.amountChanged,
+          event_type: 'other',
+        });
+      }
+    }
+    if (hasMediaChange) {
+      for (const fileChange of pendingFiles) {
+        await backend.post(`/fileChanges`, {
+          update_id: updateId,
+          s3_key: fileChange.s3_key,
+          file_name: fileChange.file_name,
+          file_type: fileChange.file_type,
+        });
+      }
+      for (const mediaChange of pendingMedia) {
+        await backend.post(`/mediaChange`, {
+          update_id: updateId,
+          s3_key: mediaChange.s3_key,
+          file_name: mediaChange.file_name,
+          file_type: mediaChange.file_type,
+          is_thumbnail: false,
+        });
+      }
+    }
+  }
+
+  onSave?.();
+  onClose();
+}

--- a/client/src/components/dashboard/ProgramForm/useProgramFormLoad.js
+++ b/client/src/components/dashboard/ProgramForm/useProgramFormLoad.js
@@ -1,0 +1,308 @@
+import { useEffect } from 'react';
+
+import ISO6391 from 'iso-639-1';
+
+const emptyFormState = {
+  status: null,
+  programName: null,
+  partnerOrg: null,
+  showPartnerOrgOnMap: false,
+  launchDate: null,
+  regionId: null,
+  country: null,
+  countryIsoCode: null,
+  city: null,
+  state: null,
+  students: 0,
+  graduatedStudents: 0,
+  instruments: {},
+  languages: [],
+  programDirectors: [],
+  curriculumLinks: [],
+  media: [],
+  fileChanges: [],
+};
+
+export function useProgramFormLoad({
+  program,
+  backend,
+  setFormState,
+  setInitialProgramDirectorIds,
+  setInitialInstrumentQuantities,
+  setInitialCurriculumLinks,
+  setInitialUploadedMedia,
+  setInitialGraduated,
+  setIsLoadingProgramData,
+}) {
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadProgramRegionData() {
+      if (!program) {
+        setIsLoadingProgramData(false);
+        setFormState(emptyFormState);
+        setInitialProgramDirectorIds([]);
+        setInitialInstrumentQuantities({});
+        setInitialCurriculumLinks([]);
+        setInitialUploadedMedia([]);
+        setInitialGraduated(0);
+        return;
+      }
+
+      setIsLoadingProgramData(true);
+
+      let record = program;
+      try {
+        const { data } = await backend.get(`/program/${program.id}`);
+        record = {
+          ...program,
+          ...data,
+          programDirectors: program.programDirectors ?? [],
+          regionalDirectors: program.regionalDirectors ?? [],
+          playlists: program.playlists ?? [],
+          media: program.media ?? [],
+          fileChanges: program.fileChanges ?? [],
+        };
+      } catch (err) {
+        console.error('ProgramForm: could not load program details', err);
+      }
+
+      try {
+        const mediaRes = await backend.get(`/program/${program.id}/media`);
+        if (Array.isArray(mediaRes.data)) {
+          record = { ...record, media: mediaRes.data };
+        }
+      } catch (err) {
+        console.error('ProgramForm: could not load program media', err);
+      }
+
+      try {
+        const filesRes = await backend.get(
+          `/fileChanges/program/${program.id}`
+        );
+        if (Array.isArray(filesRes.data)) {
+          record = { ...record, fileChanges: filesRes.data };
+        }
+      } catch (err) {
+        console.error('ProgramForm: could not load program file changes', err);
+      }
+
+      try {
+        const pdRes = await backend.get(
+          `/program/${program.id}/program-directors`
+        );
+        if (Array.isArray(pdRes.data)) {
+          record = { ...record, programDirectors: pdRes.data };
+        }
+      } catch (err) {
+        console.error('ProgramForm: could not load program directors', err);
+      }
+
+      let regionId = null;
+      let countryIsoCode = null;
+
+      if (record.country) {
+        try {
+          const countryResponse = await backend.get(
+            `/country/${record.country}`
+          );
+          regionId = countryResponse.data.regionId;
+          const rawIso =
+            countryResponse.data.isoCode ?? countryResponse.data.iso_code;
+          if (
+            rawIso !== null &&
+            rawIso !== undefined &&
+            String(rawIso).trim() !== ''
+          ) {
+            countryIsoCode = String(rawIso).trim().toUpperCase();
+          }
+        } catch (error) {
+          console.error('error fetching country/region', error);
+        }
+      }
+
+      const mappedProgramDirectors = (record.programDirectors ?? []).map(
+        (d) => ({
+          userId: d.userId ?? d.id ?? d.user_id,
+          firstName: d.firstName,
+          lastName: d.lastName,
+          picture: d.picture,
+        })
+      );
+      const programDirectorsForForm = mappedProgramDirectors.slice(0, 1);
+
+      const instrumentMap = {};
+      const initialInstrumentMap = {};
+      try {
+        const instrumentsResponse = await backend.get(
+          `/program/${record.id}/instruments`
+        );
+        const instruments = instrumentsResponse.data || [];
+        instruments.forEach((inst) => {
+          const id = inst.instrumentId ?? inst.id;
+          if (!id) return;
+          const qty = inst.quantity ?? 0;
+          if (qty === 0) return;
+          instrumentMap[id] = {
+            id,
+            name: inst.name,
+            quantity: qty,
+          };
+          initialInstrumentMap[id] = qty;
+        });
+      } catch (err) {
+        console.error('Error fetching program instruments:', err);
+      }
+
+      const normalizedLanguages = (() => {
+        if (Array.isArray(record.languages)) {
+          return [
+            ...new Set(
+              record.languages
+                .map((value) => String(value).trim().toLowerCase())
+                .filter((value) => ISO6391.validate(value))
+            ),
+          ];
+        }
+        const existingValue = record.primaryLanguage;
+        if (!existingValue) return [];
+        const trimmedValue = String(existingValue).trim();
+        if (ISO6391.validate(trimmedValue.toLowerCase())) {
+          return [trimmedValue.toLowerCase()];
+        }
+        const mappedCode = ISO6391.getCode(trimmedValue);
+        return mappedCode ? [mappedCode.toLowerCase()] : [];
+      })();
+
+      let graduatedTotal = 0;
+      let sumEnrollment = 0;
+      try {
+        const aggRes = await backend.get(
+          `/program/${record.id}/enrollment-aggregates`
+        );
+        graduatedTotal = Number(aggRes.data?.sumGraduated ?? 0);
+        sumEnrollment = Number(aggRes.data?.sumEnrollment ?? 0);
+      } catch (error) {
+        console.error('Error fetching enrollment aggregates:', error);
+      }
+      if (Number.isNaN(graduatedTotal)) graduatedTotal = 0;
+      if (Number.isNaN(sumEnrollment)) sumEnrollment = 0;
+      setInitialGraduated(graduatedTotal);
+
+      const netStudentsFromAgg = sumEnrollment - graduatedTotal;
+      const resolvedStudents =
+        record.students !== null && record.students !== undefined
+          ? Number(record.students)
+          : netStudentsFromAgg;
+
+      setFormState({
+        status: record.status ?? null,
+        programName: record.title ?? '',
+        partnerOrg: record.partnerOrg ?? record.partner_org ?? null,
+        showPartnerOrgOnMap:
+          record.showPartnerOrgOnMap ?? record.show_partner_org_on_map ?? false,
+        launchDate: record.launchDate ? record.launchDate.split('T')[0] : '',
+        regionId: regionId,
+        state: record.state ?? null,
+        city:
+          record.city !== null &&
+          record.city !== undefined &&
+          record.city !== ''
+            ? Number(record.city)
+            : null,
+        country: record.country ?? null,
+        countryIsoCode,
+        students: Number.isNaN(resolvedStudents) ? 0 : resolvedStudents,
+        graduatedStudents: graduatedTotal,
+        instruments: instrumentMap,
+        languages: normalizedLanguages,
+
+        programDirectors: programDirectorsForForm,
+
+        curriculumLinks: Array.isArray(record.playlists)
+          ? record.playlists
+              .filter(
+                (p) =>
+                  p.link &&
+                  ((p.instrumentId !== null && p.instrumentId !== undefined) ||
+                    (p.instrument_id !== null && p.instrument_id !== undefined))
+              )
+              .map((p) => ({
+                link: p.link,
+                name: p.name || 'Playlist',
+                instrumentId: p.instrumentId ?? p.instrument_id,
+                instrumentName: p.instrumentName ?? p.instrument_name ?? '',
+              }))
+          : [],
+
+        media: Array.isArray(record.media)
+          ? record.media.map((m) => ({
+              id: m.id,
+              s3_key: m.s3_key,
+              file_name: m.file_name,
+              file_type: m.file_type,
+              description: m.description ?? null,
+            }))
+          : [],
+
+        fileChanges: Array.isArray(record.fileChanges)
+          ? record.fileChanges.map((f) => ({
+              id: f.id,
+              s3_key: f.s3_key,
+              file_name: f.file_name,
+              file_type: f.file_type,
+              description: f.description ?? null,
+            }))
+          : [],
+      });
+
+      setInitialProgramDirectorIds(
+        mappedProgramDirectors.map((d) => d.userId).filter(Boolean)
+      );
+      setInitialInstrumentQuantities(initialInstrumentMap);
+      setInitialCurriculumLinks(
+        (record.playlists ?? [])
+          .filter(
+            (p) =>
+              p.link &&
+              ((p.instrumentId !== null && p.instrumentId !== undefined) ||
+                (p.instrument_id !== null && p.instrument_id !== undefined))
+          )
+          .map((p) => ({
+            link: p.link,
+            instrumentId: p.instrumentId ?? p.instrument_id,
+          }))
+      );
+
+      setInitialUploadedMedia(
+        [...(record.media ?? []), ...(record.fileChanges ?? [])]
+          .filter((m) => m.file_name)
+          .map((m) => m.file_name)
+      );
+    }
+
+    (async () => {
+      try {
+        await loadProgramRegionData();
+      } finally {
+        if (!cancelled) {
+          setIsLoadingProgramData(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    program,
+    backend,
+    setFormState,
+    setInitialProgramDirectorIds,
+    setInitialInstrumentQuantities,
+    setInitialCurriculumLinks,
+    setInitialUploadedMedia,
+    setInitialGraduated,
+    setIsLoadingProgramData,
+  ]);
+}

--- a/client/src/components/map/ProgramInfoView.jsx
+++ b/client/src/components/map/ProgramInfoView.jsx
@@ -1,0 +1,552 @@
+import { useEffect, useState } from 'react';
+
+import {
+  Badge,
+  Box,
+  Button,
+  Flex,
+  Heading,
+  HStack,
+  Icon,
+  Image,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+
+import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { formatMonthYear } from '@/utils/formatDate';
+import { isoCodeToFlagIconCode } from '@/utils/isoCodeToFlagIconCode';
+
+import { ProgramMediaGallery } from './ProgramMediaGallery';
+
+import 'flag-icons/css/flag-icons.min.css';
+
+import { GetCity, GetCountries, GetState } from 'react-country-state-city';
+import {
+  BsCalendar2,
+  BsFillRecordFill,
+  BsMusicNoteBeamed,
+  BsPersonFill,
+} from 'react-icons/bs';
+
+const ProgramInfoView = ({ program }) => {
+  const { backend } = useBackendContext();
+  const [students, setStudents] = useState(0);
+  const [instrumentsList, setInstrumentsList] = useState([]);
+  const [totalInstruments, setTotalInstruments] = useState(0);
+  const [directors, setDirectors] = useState([]);
+  const [media, setMedia] = useState([]);
+  const [mediaUrls, setMediaUrls] = useState({});
+  const [directorPicUrls, setDirectorPicUrls] = useState({});
+  const [locationName, setLocationName] = useState('');
+  const [flagCode, setFlagCode] = useState('');
+  const [partnerOrg, setPartnerOrg] = useState('');
+
+  const programId = program.id;
+
+  const formatDateRange = (launchDate) => {
+    const start = formatMonthYear(launchDate);
+    const end = new Date().toLocaleDateString('en-US', {
+      month: 'short',
+      year: 'numeric',
+    });
+    return `${start} - ${end}`;
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const [instrumentsRes, studentsRes, directorsRes, mediaRes] =
+          await Promise.all([
+            backend.get(`/program/${programId}/instruments`),
+            backend.get(`/program/students/${programId}`),
+            backend.get(`/program/${programId}/program-directors`),
+            backend.get(`/program/${programId}/media`),
+          ]);
+
+        setInstrumentsList(instrumentsRes.data);
+        const total = instrumentsRes.data.reduce(
+          (sum, inst) => sum + Number(inst.quantity),
+          0
+        );
+        setTotalInstruments(total);
+
+        const totalStudents = studentsRes.data.reduce(
+          (sum, row) =>
+            sum + Number(row.enrollmentChange) - Number(row.graduatedChange),
+          0
+        );
+        setStudents(totalStudents);
+
+        setDirectors(directorsRes.data);
+
+        const approvedMedia = mediaRes.data.filter(
+          (m) => m.status === 'Approved'
+        );
+        const displayMedia =
+          approvedMedia.length > 0 ? approvedMedia : mediaRes.data;
+        setMedia(displayMedia);
+
+        const urls = {};
+        for (const m of displayMedia) {
+          try {
+            const urlRes = await backend.get(
+              `/images/url/${encodeURIComponent(m.s3Key || m.s3_key)}`
+            );
+            urls[m.id] = urlRes.data.url;
+          } catch (error) {
+            console.error('Error fetching media: ', error);
+          }
+        }
+        setMediaUrls(urls);
+
+        const picUrls = {};
+        for (const d of directorsRes.data) {
+          if (d.picture) {
+            try {
+              const urlRes = await backend.get(
+                `/images/url/${encodeURIComponent(d.picture)}`
+              );
+              picUrls[d.userId] = urlRes.data.url;
+            } catch (error) {
+              console.error('Error fetching media: ', error);
+            }
+          }
+        }
+        setDirectorPicUrls(picUrls);
+      } catch (error) {
+        console.error('Error fetching program details:', error);
+      }
+    };
+
+    const fetchPartnerOrg = async () => {
+      try {
+        const partnerRes = await backend.get(
+          `/program/${programId}/partner-organization`
+        );
+        setPartnerOrg(partnerRes.data);
+      } catch (error) {
+        console.error('Error fetching partner organization: ', error);
+      }
+    };
+
+    fetchData();
+    fetchPartnerOrg();
+  }, [programId, backend]);
+
+  useEffect(() => {
+    const fetchLocation = async () => {
+      try {
+        const countryRes = await backend.get(`/country/${program.country}`);
+        const countries = await GetCountries();
+        const foundCountry = countries.find(
+          (c) => String(c.iso3) === String(countryRes.data.isoCode)
+        );
+        if (foundCountry) {
+          let name = foundCountry.name;
+          setFlagCode(isoCodeToFlagIconCode(countryRes.data.isoCode));
+          if (program.state) {
+            const states = await GetState(parseInt(foundCountry.id));
+            const foundState = states.find(
+              (s) => parseInt(s.id) === parseInt(program.state)
+            );
+            if (foundState) {
+              const cities = await GetCity(foundCountry.id, foundState.id);
+              const foundCity = cities.find(
+                (c) => parseInt(c.id) === parseInt(program.city)
+              );
+              name = foundCity
+                ? `${foundCity.name}, ${foundCountry.name}`
+                : foundCountry.name;
+            }
+          }
+          setLocationName(name);
+        }
+      } catch (error) {
+        console.error('Error fetching location:', error);
+      }
+    };
+    fetchLocation();
+  }, [program.country, program.state, program.city, backend]);
+
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      px="40px"
+      py="32px"
+      gap="32px"
+      bg="white"
+      mx="28px"
+      borderRadius="12px"
+    >
+      <VStack
+        align="flex-start"
+        spacing="12px"
+        w="100%"
+      >
+        <Badge
+          bg="#2C7A7B"
+          color="white"
+          borderRadius="6px"
+          px="12px"
+          h="25px"
+          display="flex"
+          alignItems="center"
+          fontSize="12px"
+          fontWeight="500"
+          textTransform="none"
+        >
+          {partnerOrg}
+        </Badge>
+        <Heading
+          fontWeight="700"
+          fontSize="36px"
+          lineHeight="48px"
+          letterSpacing="-0.85px"
+          color="#101828"
+        >
+          {program.title}
+        </Heading>
+        <HStack spacing="8px">
+          {flagCode && (
+            <span
+              className={`fi fi-${flagCode}`}
+              aria-hidden="true"
+            />
+          )}
+          <Text
+            fontSize="12px"
+            lineHeight="28px"
+            letterSpacing="-0.44px"
+            color="#4A5565"
+          >
+            {locationName}
+          </Text>
+        </HStack>
+      </VStack>
+
+      <VStack
+        align="flex-start"
+        spacing="24px"
+        w="100%"
+      >
+        <Heading
+          fontWeight="700"
+          fontSize="28px"
+          lineHeight="44px"
+          color="#000000"
+        >
+          Program Overview
+        </Heading>
+
+        <Flex
+          gap="40px"
+          w="100%"
+          justify="space-between"
+        >
+          <Box
+            w="100%"
+            h="218px"
+            bgGradient="linear(135deg, #FFFFFF 0%, rgba(240, 253, 250, 0.3) 100%)"
+            border="1px solid rgba(203, 251, 241, 0.5)"
+            boxShadow="0px 4px 6px -1px rgba(0, 0, 0, 0.1), 0px 2px 4px -2px rgba(0, 0, 0, 0.1)"
+            borderRadius="16px"
+            position="relative"
+            px="25px"
+            pt="57px"
+          >
+            <Icon
+              as={BsPersonFill}
+              color="#319795"
+              boxSize="24px"
+              mb="8px"
+            />
+            <Text
+              fontWeight="700"
+              fontSize="36px"
+              lineHeight="40px"
+              letterSpacing="0.37px"
+              color="#101828"
+            >
+              {students}
+            </Text>
+            <Text
+              fontWeight="500"
+              fontSize="14px"
+              lineHeight="20px"
+              letterSpacing="-0.15px"
+              color="#4A5565"
+              mt="8px"
+            >
+              Students Enrolled
+            </Text>
+          </Box>
+
+          <Box
+            w="100%"
+            h="218px"
+            bgGradient="linear(135deg, #FFFFFF 0%, rgba(240, 253, 250, 0.3) 100%)"
+            border="1px solid rgba(203, 251, 241, 0.5)"
+            boxShadow="0px 4px 6px -1px rgba(0, 0, 0, 0.1), 0px 2px 4px -2px rgba(0, 0, 0, 0.1)"
+            borderRadius="16px"
+            position="relative"
+            px="25px"
+            pt="57px"
+          >
+            <Icon
+              as={BsMusicNoteBeamed}
+              color="#319795"
+              boxSize="24px"
+              mb="8px"
+            />
+            <Text
+              fontWeight="700"
+              fontSize="36px"
+              lineHeight="40px"
+              letterSpacing="0.37px"
+              color="#101828"
+            >
+              {totalInstruments}
+            </Text>
+            <Text
+              fontWeight="500"
+              fontSize="14px"
+              lineHeight="20px"
+              letterSpacing="-0.15px"
+              color="#4A5565"
+              mt="8px"
+            >
+              instruments donated
+            </Text>
+            {instrumentsList.length > 0 && (
+              <HStack
+                spacing="16px"
+                mt="8px"
+              >
+                {instrumentsList.map((inst) => (
+                  <Text
+                    key={inst.instrumentId}
+                    fontWeight="500"
+                    fontSize="14px"
+                    lineHeight="20px"
+                    letterSpacing="-0.15px"
+                    color="#4A5565"
+                  >
+                    &bull; {inst.quantity} {inst.name}
+                  </Text>
+                ))}
+              </HStack>
+            )}
+          </Box>
+
+          <Box
+            w="100%"
+            h="218px"
+            bgGradient="linear(135deg, #FFFFFF 0%, rgba(240, 253, 250, 0.3) 100%)"
+            border="1px solid rgba(203, 251, 241, 0.5)"
+            boxShadow="0px 4px 6px -1px rgba(0, 0, 0, 0.1), 0px 2px 4px -2px rgba(0, 0, 0, 0.1)"
+            borderRadius="16px"
+            position="relative"
+            px="25px"
+            pt="24px"
+          >
+            <Badge
+              bg="#E6FFFA"
+              color="#2C7A7B"
+              borderRadius="6px"
+              px="8px"
+              h="24px"
+              display="flex"
+              alignItems="center"
+              gap="8px"
+              fontSize="14px"
+              fontWeight="500"
+              textTransform="none"
+              position="absolute"
+              right="24px"
+              top="24px"
+            >
+              {program.status === 'Inactive' ? 'Developing' : 'Launched'}
+              <Icon
+                as={BsFillRecordFill}
+                color="#319795"
+                boxSize="16px"
+              />
+            </Badge>
+            <Box mt="33px">
+              <Icon
+                as={BsCalendar2}
+                color="#319795"
+                boxSize="24px"
+                mb="8px"
+              />
+              <Text
+                fontWeight="700"
+                fontSize="30px"
+                lineHeight="40px"
+                letterSpacing="0.37px"
+                color="#101828"
+              >
+                {formatDateRange(program.launchDate)}
+              </Text>
+              <Text
+                fontWeight="500"
+                fontSize="14px"
+                lineHeight="20px"
+                letterSpacing="-0.15px"
+                color="#4A5565"
+                mt="8px"
+              >
+                Program Timeline
+              </Text>
+            </Box>
+          </Box>
+        </Flex>
+      </VStack>
+
+      {directors.length > 0 && (
+        <Box
+          w="100%"
+          bg="#E6FFFA"
+          boxShadow="0px 4px 4px rgba(0, 0, 0, 0.25)"
+          borderRadius="12px"
+          p="24px"
+        >
+          <Heading
+            fontWeight="600"
+            fontSize="28px"
+            lineHeight="44px"
+            color="#000000"
+            mb="24px"
+          >
+            {directors.length > 1 ? 'Meet the Directors' : 'Meet the Director'}
+          </Heading>
+          {directors.map((director) => (
+            <Flex
+              key={director.userId}
+              gap="32px"
+              align="flex-start"
+              pb="20px"
+            >
+              <Image
+                src={directorPicUrls[director.userId]}
+                alt={`${director.firstName} ${director.lastName}`}
+                w="175px"
+                h="175px"
+                borderRadius="12px"
+                objectFit="cover"
+                flexShrink={0}
+                fallback={
+                  <Flex
+                    w="175px"
+                    h="175px"
+                    borderRadius="12px"
+                    bg="gray.200"
+                    align="center"
+                    justify="center"
+                    flexShrink={0}
+                  >
+                    <Icon
+                      as={BsPersonFill}
+                      boxSize="60px"
+                      color="gray.400"
+                    />
+                  </Flex>
+                }
+              />
+              <VStack
+                align="flex-start"
+                spacing="12px"
+                flex={1}
+              >
+                <VStack
+                  align="flex-start"
+                  spacing="8px"
+                >
+                  <Text
+                    fontWeight="700"
+                    fontSize="24px"
+                    lineHeight="29px"
+                    color="#000000"
+                  >
+                    {director.firstName} {director.lastName}
+                  </Text>
+                  <Text
+                    fontWeight="700"
+                    fontSize="16px"
+                    lineHeight="19px"
+                    color="#319795"
+                  >
+                    Program Director
+                  </Text>
+                </VStack>
+                {director.bio?.trim() && (
+                  <Text
+                    fontWeight="400"
+                    fontSize="15px"
+                    lineHeight="24px"
+                    color="#4A5565"
+                    whiteSpace="pre-wrap"
+                  >
+                    {director.bio.trim()}
+                  </Text>
+                )}
+              </VStack>
+            </Flex>
+          ))}
+        </Box>
+      )}
+
+      <ProgramMediaGallery
+        media={media}
+        mediaUrls={mediaUrls}
+      />
+
+      <Flex
+        w="100%"
+        h="300px"
+        bgGradient="linear(100.45deg, #FFFFFF -34.33%, #20ABA8 50.52%, #FFFFFF 123.24%)"
+        boxShadow="0px 5px 3px rgba(0, 0, 0, 0.45)"
+        borderRadius="12px"
+        justify="center"
+        align="center"
+        py="8px"
+      >
+        <VStack
+          h="300px"
+          justify="center"
+        >
+          <Heading
+            fontWeight="600"
+            fontSize="40px"
+            lineHeight="70px"
+            color="white"
+            textAlign="center"
+          >
+            Make a difference Today
+          </Heading>
+          <Button
+            as="a"
+            href="https://givebutter.com/Donate-GCF"
+            target="_blank"
+            bg="white"
+            color="#2C7A7B"
+            borderRadius="12px"
+            px="48px"
+            h="70px"
+            fontSize="20px"
+            fontWeight="600"
+            lineHeight="56px"
+            boxShadow="0px 4px 4px rgba(0, 0, 0, 0.25)"
+            _hover={{ bg: 'gray.50' }}
+          >
+            Donate Now
+          </Button>
+        </VStack>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default ProgramInfoView;

--- a/client/src/components/map/ProgramMediaGallery.jsx
+++ b/client/src/components/map/ProgramMediaGallery.jsx
@@ -1,0 +1,291 @@
+import { useState } from 'react';
+
+import {
+  Box,
+  Center,
+  Flex,
+  Heading,
+  HStack,
+  Icon,
+  Image,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+  VStack,
+} from '@chakra-ui/react';
+
+import { useTranslation } from 'react-i18next';
+import { FiPlay } from 'react-icons/fi';
+
+const mediaFileType = (m) => m?.file_type ?? m?.fileType ?? '';
+
+const isVideoMedia = (m) => mediaFileType(m).startsWith('video');
+
+const isPdfMedia = (m) => mediaFileType(m) === 'application/pdf';
+
+const mediaDisplayName = (m) => m?.fileName ?? m?.file_name ?? '';
+
+export const ProgramMediaGallery = ({ media, mediaUrls }) => {
+  const { t } = useTranslation();
+  const {
+    isOpen: isGalleryPreviewOpen,
+    onOpen: onGalleryPreviewOpen,
+    onClose: onGalleryPreviewClose,
+  } = useDisclosure();
+  const [galleryPreviewItem, setGalleryPreviewItem] = useState(null);
+
+  const openGalleryPreview = (item) => {
+    setGalleryPreviewItem(item);
+    onGalleryPreviewOpen();
+  };
+
+  const closeGalleryPreview = () => {
+    setGalleryPreviewItem(null);
+    onGalleryPreviewClose();
+  };
+
+  const galleryPreviewUrl = galleryPreviewItem
+    ? mediaUrls[galleryPreviewItem.id]
+    : null;
+
+  const galleryPreviewDescription =
+    typeof galleryPreviewItem?.description === 'string' &&
+    galleryPreviewItem.description.trim() !== ''
+      ? galleryPreviewItem.description.trim()
+      : null;
+
+  if (!media.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <VStack
+        align="flex-start"
+        spacing="24px"
+        w="100%"
+        py="24px"
+      >
+        <Heading
+          fontWeight="600"
+          fontSize="28px"
+          lineHeight="44px"
+          color="#000000"
+        >
+          Gallery
+        </Heading>
+        <HStack
+          spacing="16px"
+          overflowX="auto"
+          w="100%"
+          css={{
+            '&::-webkit-scrollbar': { display: 'none' },
+            scrollbarWidth: 'none',
+          }}
+        >
+          {media.map((m) =>
+            mediaUrls[m.id] ? (
+              <Box
+                key={m.id}
+                position="relative"
+                w="300px"
+                h="300px"
+                flexShrink={0}
+                borderRadius="12px"
+                overflow="hidden"
+                filter="drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))"
+                role="button"
+                tabIndex={0}
+                cursor="pointer"
+                onClick={() => openGalleryPreview(m)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openGalleryPreview(m);
+                  }
+                }}
+                aria-label={t('mediaPreviewTag.openPreview')}
+                _hover={{
+                  '& .gallery-card-overlay': { opacity: 1 },
+                }}
+              >
+                {isVideoMedia(m) ? (
+                  <>
+                    <video
+                      src={mediaUrls[m.id]}
+                      muted
+                      playsInline
+                      loop
+                      style={{
+                        width: '100%',
+                        height: '100%',
+                        objectFit: 'cover',
+                        display: 'block',
+                      }}
+                    />
+                    <Center
+                      position="absolute"
+                      inset={0}
+                      pointerEvents="none"
+                    >
+                      <Box
+                        bg="blackAlpha.600"
+                        borderRadius="full"
+                        p={3}
+                      >
+                        <Icon
+                          as={FiPlay}
+                          color="white"
+                          boxSize={6}
+                        />
+                      </Box>
+                    </Center>
+                  </>
+                ) : isPdfMedia(m) ? (
+                  <iframe
+                    src={mediaUrls[m.id]}
+                    title={mediaDisplayName(m)}
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      border: 'none',
+                      pointerEvents: 'none',
+                    }}
+                  />
+                ) : (
+                  <Image
+                    src={mediaUrls[m.id]}
+                    alt={mediaDisplayName(m)}
+                    w="100%"
+                    h="100%"
+                    objectFit="cover"
+                  />
+                )}
+                <Flex
+                  className="gallery-card-overlay"
+                  position="absolute"
+                  top={0}
+                  left={0}
+                  w="100%"
+                  h="100%"
+                  zIndex={2}
+                  bg="blackAlpha.600"
+                  opacity={0}
+                  transition="opacity 0.3s"
+                  direction="column"
+                  justify="flex-end"
+                  p="16px"
+                >
+                  <Text
+                    color="white"
+                    fontWeight="700"
+                    fontSize="16px"
+                    lineHeight="20px"
+                  >
+                    {mediaDisplayName(m)}
+                  </Text>
+                  {m.description && (
+                    <Text
+                      color="whiteAlpha.800"
+                      fontSize="13px"
+                      lineHeight="18px"
+                      mt="4px"
+                    >
+                      {m.description}
+                    </Text>
+                  )}
+                </Flex>
+              </Box>
+            ) : null
+          )}
+        </HStack>
+      </VStack>
+
+      <Modal
+        isOpen={isGalleryPreviewOpen}
+        onClose={closeGalleryPreview}
+        size={
+          galleryPreviewItem && isPdfMedia(galleryPreviewItem) ? '6xl' : '4xl'
+        }
+        isCentered
+        portalProps={{ zIndex: 2000 }}
+      >
+        <ModalOverlay bg="blackAlpha.600" />
+        <ModalContent maxH="90vh">
+          <ModalCloseButton />
+          <ModalBody
+            p={4}
+            pt={10}
+          >
+            <Text
+              fontWeight="semibold"
+              mb={3}
+              noOfLines={2}
+            >
+              {galleryPreviewItem ? mediaDisplayName(galleryPreviewItem) : ''}
+            </Text>
+            <Box
+              borderRadius="md"
+              overflow="hidden"
+              bg="gray.900"
+              minH={
+                galleryPreviewItem && isPdfMedia(galleryPreviewItem)
+                  ? '75vh'
+                  : 'auto'
+              }
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+            >
+              {galleryPreviewUrl &&
+              galleryPreviewItem &&
+              isVideoMedia(galleryPreviewItem) ? (
+                <video
+                  src={galleryPreviewUrl}
+                  controls
+                  style={{
+                    maxWidth: '100%',
+                    maxHeight: '75vh',
+                    width: '100%',
+                  }}
+                />
+              ) : galleryPreviewUrl &&
+                galleryPreviewItem &&
+                isPdfMedia(galleryPreviewItem) ? (
+                <iframe
+                  src={galleryPreviewUrl}
+                  title={mediaDisplayName(galleryPreviewItem)}
+                  style={{
+                    width: '100%',
+                    height: '75vh',
+                    border: 'none',
+                  }}
+                />
+              ) : galleryPreviewUrl && galleryPreviewItem ? (
+                <Image
+                  src={galleryPreviewUrl}
+                  alt={mediaDisplayName(galleryPreviewItem)}
+                  maxH="75vh"
+                  maxW="100%"
+                  objectFit="contain"
+                />
+              ) : null}
+            </Box>
+            <Text
+              fontSize="sm"
+              color="gray.500"
+              mt={4}
+              whiteSpace="pre-wrap"
+            >
+              {galleryPreviewDescription ?? t('mediaCard.noDescription')}
+            </Text>
+          </ModalBody>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};

--- a/client/src/components/profile/ProfileView.jsx
+++ b/client/src/components/profile/ProfileView.jsx
@@ -1,0 +1,447 @@
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  Grid,
+  GridItem,
+  IconButton,
+  Image,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Select,
+  Spinner,
+  Text,
+  Textarea,
+  VStack,
+} from '@chakra-ui/react';
+
+import { APP_LOCALES } from '@/i18n';
+import { useTranslation } from 'react-i18next';
+import {
+  FiCamera,
+  FiCheck,
+  FiEdit2,
+  FiEye,
+  FiEyeOff,
+  FiX,
+} from 'react-icons/fi';
+
+import { MediaUploadModal } from '../media/MediaUploadModal';
+import { ChangePasswordModal } from './ChangePasswordModal';
+
+export const ProfileView = (props) => {
+  const { t } = useTranslation();
+  const {
+    loading,
+    gcfUser,
+    currentUser,
+    role,
+    roleSpecificData,
+    isEditing,
+    formData,
+    showPassword,
+    setShowPassword,
+    newPassword,
+    setNewPassword,
+    setPasswordEdited,
+    profilePicture,
+    pdPending,
+    firstNamePending,
+    lastNamePending,
+    bioPending,
+    picturePending,
+    localeLabel,
+    handleEdit,
+    handleCancel,
+    handleSave,
+    handleInputChange,
+    handleProfilePictureUpload,
+    handlePasswordChangeSuccess,
+    isOpen,
+    onOpen,
+    onClose,
+    isPasswordModalOpen,
+    onPasswordModelClose,
+  } = props;
+
+  if (loading) {
+    return (
+      <Box
+        h="100vh"
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Spinner size="xl" />
+      </Box>
+    );
+  }
+
+  if (!gcfUser) {
+    return (
+      <Box
+        p={10}
+        bg="gray.50"
+        minH="94vh"
+        mx={-4}
+      >
+        <Text>Unable to load your profile. Please try again later.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      p={10}
+      position="relative"
+      bg="gray.50"
+      minH="94vh"
+      mx={-4}
+      mt={0}
+    >
+      {!isEditing && (
+        <Flex
+          justify="flex-end"
+          mb={4}
+        >
+          <Button
+            leftIcon={<FiEdit2 />}
+            bg="teal.500"
+            color="white"
+            borderRadius="md"
+            _hover={{ bg: 'teal.600' }}
+            onClick={handleEdit}
+          >
+            {t('profile.edit')}
+          </Button>
+        </Flex>
+      )}
+
+      {isEditing && <Box h="52px" />}
+
+      <VStack
+        spacing={8}
+        align="center"
+        w="100%"
+      >
+        <Box
+          position="relative"
+          display="inline-block"
+        >
+          <Image
+            src={profilePicture}
+            boxSize="200px"
+            borderRadius="full"
+            fit="cover"
+            alt={t('accountForm.profileAlt')}
+          />
+          {isEditing && (
+            <IconButton
+              icon={<FiCamera />}
+              aria-label={t('profile.uploadPhoto')}
+              borderRadius="full"
+              size="sm"
+              bg="white"
+              boxShadow="md"
+              position="absolute"
+              bottom={2}
+              right={2}
+              onClick={onOpen}
+              _hover={{ bg: 'gray.100' }}
+            />
+          )}
+          {!isEditing && picturePending && (
+            <Text
+              as="span"
+              color="red.500"
+              fontWeight="bold"
+              fontSize="xl"
+              position="absolute"
+              top={1}
+              right={1}
+              lineHeight={1}
+            >
+              *
+            </Text>
+          )}
+        </Box>
+
+        <VStack
+          spacing={6}
+          align="flex-start"
+          w="100%"
+          maxW="700px"
+        >
+          <Grid
+            templateColumns="repeat(2, 1fr)"
+            gap={8}
+            w="100%"
+          >
+            <GridItem>
+              <Text
+                fontWeight="bold"
+                mb={1}
+              >
+                {t('common.firstName')}
+                {!isEditing && firstNamePending && (
+                  <Text
+                    as="span"
+                    color="red.500"
+                    ml={0.5}
+                  >
+                    *
+                  </Text>
+                )}
+              </Text>
+              {isEditing ? (
+                <Input
+                  value={formData.firstName}
+                  onChange={handleInputChange('firstName')}
+                />
+              ) : (
+                <Text>{gcfUser.firstName || ''}</Text>
+              )}
+            </GridItem>
+            <GridItem>
+              <Text
+                fontWeight="bold"
+                mb={1}
+              >
+                {t('common.lastName')}
+                {!isEditing && lastNamePending && (
+                  <Text
+                    as="span"
+                    color="red.500"
+                    ml={0.5}
+                  >
+                    *
+                  </Text>
+                )}
+              </Text>
+              {isEditing ? (
+                <Input
+                  value={formData.lastName}
+                  onChange={handleInputChange('lastName')}
+                />
+              ) : (
+                <Text>{gcfUser.lastName || ''}</Text>
+              )}
+            </GridItem>
+          </Grid>
+
+          {role === 'Program Director' && (
+            <FormControl>
+              <Text
+                fontWeight="bold"
+                mb={1}
+              >
+                {t('profile.bio')}
+                {!isEditing && bioPending && (
+                  <Text
+                    as="span"
+                    color="red.500"
+                    ml={0.5}
+                  >
+                    *
+                  </Text>
+                )}
+              </Text>
+              {isEditing ? (
+                <Textarea
+                  value={formData.bio || ''}
+                  onChange={handleInputChange('bio')}
+                  rows={5}
+                  resize="vertical"
+                />
+              ) : (
+                <Text whiteSpace="pre-wrap">{formData.bio || ''}</Text>
+              )}
+            </FormControl>
+          )}
+
+          <FormControl>
+            <Text
+              fontWeight="bold"
+              mb={1}
+            >
+              {t('common.email')}
+            </Text>
+            {isEditing ? (
+              <Input
+                value={formData.email}
+                onChange={handleInputChange('email')}
+                type="email"
+                isReadOnly
+                bg="gray.100"
+              />
+            ) : (
+              <Text>{currentUser?.email || ''}</Text>
+            )}
+          </FormControl>
+
+          <FormControl
+            mt={isEditing ? -4 : 0}
+            mb={isEditing ? -2 : 0}
+          >
+            <Text
+              fontWeight="bold"
+              mb={1}
+            >
+              {t('common.password')}
+            </Text>
+            {isEditing ? (
+              <InputGroup>
+                <Input
+                  type={showPassword ? 'text' : 'password'}
+                  value={newPassword}
+                  onChange={(e) => {
+                    setNewPassword(e.target.value);
+                    setPasswordEdited(true);
+                  }}
+                  placeholder="Leave blank to keep current password"
+                  autoComplete="new-password"
+                />
+                <InputRightElement>
+                  <IconButton
+                    icon={showPassword ? <FiEye /> : <FiEyeOff />}
+                    aria-label={t('profile.togglePassword')}
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowPassword(!showPassword)}
+                  />
+                </InputRightElement>
+              </InputGroup>
+            ) : (
+              <Text
+                letterSpacing="0.15em"
+                userSelect="none"
+                aria-hidden
+              >
+                {t('accountForm.passwordMaskStars')}
+              </Text>
+            )}
+          </FormControl>
+
+          {role === 'Regional Director' && roleSpecificData?.name && (
+            <FormControl>
+              <Text
+                fontWeight="bold"
+                mb={1}
+              >
+                {t('common.region')}
+              </Text>
+              {isEditing ? (
+                <Input
+                  value={roleSpecificData.name}
+                  isReadOnly
+                  bg="gray.100"
+                />
+              ) : (
+                <Text>{roleSpecificData.name}</Text>
+              )}
+            </FormControl>
+          )}
+
+          {role === 'Program Director' && roleSpecificData?.name && (
+            <FormControl>
+              <Text
+                fontWeight="bold"
+                mb={1}
+              >
+                {t('common.program')}
+              </Text>
+              {isEditing ? (
+                <Input
+                  value={roleSpecificData.name}
+                  isReadOnly
+                  bg="gray.100"
+                />
+              ) : (
+                <Text>{roleSpecificData.name}</Text>
+              )}
+            </FormControl>
+          )}
+
+          <FormControl>
+            <Text
+              fontWeight="bold"
+              mb={1}
+            >
+              {t('profile.preferredLanguage')}
+            </Text>
+            {isEditing ? (
+              <Select
+                value={formData.language}
+                onChange={handleInputChange('language')}
+              >
+                {APP_LOCALES.map((code) => (
+                  <option
+                    key={code}
+                    value={code}
+                  >
+                    {localeLabel(code)}
+                  </option>
+                ))}
+              </Select>
+            ) : (
+              <Text>{localeLabel(gcfUser?.preferredLanguage)}</Text>
+            )}
+          </FormControl>
+
+          {!isEditing && pdPending && (
+            <Text
+              color="red.500"
+              fontSize="sm"
+              textAlign="center"
+              w="100%"
+            >
+              * {t('profile.pendingApprovalDesc')}
+            </Text>
+          )}
+        </VStack>
+      </VStack>
+
+      {isEditing && (
+        <Flex
+          justify="flex-end"
+          mt={8}
+          gap={3}
+        >
+          <Button
+            leftIcon={<FiX />}
+            variant="outline"
+            onClick={handleCancel}
+          >
+            {t('common.cancel')}
+          </Button>
+          <Button
+            leftIcon={<FiCheck />}
+            bg="teal.500"
+            color="white"
+            _hover={{ bg: 'teal.600' }}
+            onClick={handleSave}
+          >
+            {t('common.save')}
+          </Button>
+        </Flex>
+      )}
+
+      <MediaUploadModal
+        isOpen={isOpen}
+        onClose={onClose}
+        onUploadComplete={handleProfilePictureUpload}
+        formOrigin="profile"
+      />
+
+      <ChangePasswordModal
+        isOpen={isPasswordModalOpen}
+        onClose={onPasswordModelClose}
+        newPassword={newPassword}
+        currentUser={currentUser}
+        onSuccess={handlePasswordChangeSuccess}
+      />
+    </Box>
+  );
+};

--- a/client/src/components/profile/constants.js
+++ b/client/src/components/profile/constants.js
@@ -1,0 +1,1 @@
+export const DEFAULT_PROFILE_IMAGE = '/default-profile.png';

--- a/client/src/components/profile/profileFetchers.js
+++ b/client/src/components/profile/profileFetchers.js
@@ -1,0 +1,27 @@
+export const fetchProgramData = async (backend, userId) => {
+  try {
+    const response = await backend.get(
+      `/program-directors/me/${userId}/program`
+    );
+    return response.data;
+  } catch (err) {
+    console.error('Error fetching program data:', err);
+    return null;
+  }
+};
+
+export const fetchRegionData = async (backend, userId) => {
+  try {
+    const rdResponse = await backend.get(`/regional-directors/me/${userId}`);
+    if (rdResponse.data?.regionId) {
+      const regionResponse = await backend.get(
+        `/region/${rdResponse.data.regionId}`
+      );
+      return regionResponse.data;
+    }
+    return null;
+  } catch (err) {
+    console.error('Error fetching region data:', err);
+    return null;
+  }
+};

--- a/client/src/components/profile/useProfile.js
+++ b/client/src/components/profile/useProfile.js
@@ -1,0 +1,601 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useDisclosure, useToast } from '@chakra-ui/react';
+
+import { useAuthContext } from '@/contexts/hooks/useAuthContext';
+import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { useRoleContext } from '@/contexts/hooks/useRoleContext';
+import i18n, { isAppLocale } from '@/i18n';
+import { useTranslation } from 'react-i18next';
+
+import { DEFAULT_PROFILE_IMAGE } from './constants';
+import { fetchProgramData, fetchRegionData } from './profileFetchers';
+
+export const useProfile = () => {
+  const { t } = useTranslation();
+  const { currentUser } = useAuthContext();
+  const { role } = useRoleContext();
+  const { backend } = useBackendContext();
+  const toast = useToast();
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isPasswordModalOpen,
+    onOpen: onPasswordModelOpen,
+    onClose: onPasswordModelClose,
+  } = useDisclosure();
+
+  const [gcfUser, setGcfUser] = useState(null);
+  const [roleSpecificData, setRoleSpecificData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [passwordEdited, setPasswordEdited] = useState(false);
+  const [newPassword, setNewPassword] = useState('');
+
+  const profileEditBaselineRef = useRef(null);
+  const [pendingPictureKey, setPendingPictureKey] = useState(null);
+  const [pendingPicturePreviewUrl, setPendingPicturePreviewUrl] =
+    useState(null);
+  const [pendingAccountChange, setPendingAccountChange] = useState(null);
+
+  const [formData, setFormData] = useState({
+    firstName: '',
+    lastName: '',
+    email: '',
+    language: 'en',
+    bio: '',
+  });
+
+  const localeLabel = (code) => {
+    const c = isAppLocale(String(code)) ? code : 'en';
+    switch (c) {
+      case 'es':
+        return t('profile.langSpanish');
+      case 'fr':
+        return t('profile.langFrench');
+      case 'zh':
+        return t('profile.langChinese');
+      default:
+        return t('profile.langEnglish');
+    }
+  };
+
+  const fetchUserData = useCallback(async () => {
+    if (!currentUser?.uid) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const userResponse = await backend.get(`/gcf-users/${currentUser.uid}`);
+      const userData = userResponse.data;
+      const pictureKey =
+        userData.picture && userData.picture.trim() !== ''
+          ? userData.picture
+          : null;
+
+      userData.pictureKey = pictureKey;
+
+      if (pictureKey) {
+        try {
+          const urlResponse = await backend.get(
+            `/images/url/${encodeURIComponent(pictureKey)}`
+          );
+          userData.picture = urlResponse.data.url;
+        } catch (urlErr) {
+          console.error('Error fetching profile image:', urlErr);
+          userData.picture = null;
+        }
+      }
+
+      setGcfUser(userData);
+      const prefLang =
+        userData.preferredLanguage &&
+        isAppLocale(String(userData.preferredLanguage))
+          ? String(userData.preferredLanguage)
+          : 'en';
+      setFormData({
+        firstName: userData.firstName || '',
+        lastName: userData.lastName || '',
+        email: currentUser?.email || '',
+        bio: '',
+        language: prefLang,
+      });
+
+      if (role === 'Program Director') {
+        const programData = await fetchProgramData(backend, userData.id);
+        setRoleSpecificData(programData);
+
+        let pendingChange = null;
+        try {
+          const pendingResponse = await backend.get('/accountChange', {
+            params: { userId: currentUser.uid, resolved: 'false' },
+          });
+          const pendingList = pendingResponse.data || [];
+          if (pendingList.length > 0) {
+            pendingChange = pendingList.sort(
+              (a, b) => new Date(b.lastModified) - new Date(a.lastModified)
+            )[0];
+          }
+        } catch (err) {
+          console.error('Error fetching pending account changes:', err);
+        }
+
+        if (pendingChange) {
+          const nv = pendingChange.newValues || {};
+          const displayFirstName =
+            nv.first_name !== undefined
+              ? nv.first_name
+              : (userData.firstName ?? '');
+          const displayLastName =
+            nv.last_name !== undefined
+              ? nv.last_name
+              : (userData.lastName ?? '');
+          const displayBio =
+            nv.bio !== undefined ? nv.bio : programData?.bio || '';
+
+          setRoleSpecificData((prev) => ({ ...prev, bio: displayBio }));
+          setFormData({
+            firstName: displayFirstName,
+            lastName: displayLastName,
+            email: currentUser?.email || '',
+            bio: displayBio,
+            language: prefLang,
+          });
+
+          let pendingPic = null;
+          if (nv.picture && nv.picture !== pictureKey) {
+            try {
+              const urlResp = await backend.get(
+                `/images/url/${encodeURIComponent(nv.picture)}`
+              );
+              pendingPic = urlResp.data.url;
+            } catch {
+              // ignore
+            }
+          }
+
+          setGcfUser((prev) => ({
+            ...prev,
+            firstName: displayFirstName,
+            lastName: displayLastName,
+            ...(pendingPic ? { picture: pendingPic } : {}),
+          }));
+          setPendingAccountChange(pendingChange);
+        } else {
+          setFormData((prev) => ({ ...prev, bio: programData?.bio || '' }));
+          setPendingAccountChange(null);
+        }
+      } else if (role === 'Regional Director') {
+        const regionData = await fetchRegionData(backend, userData.id);
+        setRoleSpecificData(regionData);
+      }
+    } catch (err) {
+      console.error('Error fetching user data:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [currentUser?.uid, currentUser?.email, backend, role]);
+
+  useEffect(() => {
+    fetchUserData();
+  }, [fetchUserData]);
+
+  const handleProfilePictureUpload = async (uploadedFiles) => {
+    if (!uploadedFiles?.length) return;
+
+    const key = uploadedFiles[0].s3_key;
+
+    try {
+      const urlResponse = await backend.get(
+        `/images/url/${encodeURIComponent(key)}`
+      );
+
+      if (role === 'Program Director') {
+        setPendingPictureKey(key);
+        setPendingPicturePreviewUrl(urlResponse.data.url);
+        return;
+      }
+
+      await backend.post('/images/profile-picture', {
+        key: key,
+        userId: currentUser.uid,
+      });
+
+      const prevPictureKey = gcfUser?.pictureKey || null;
+      const nextPictureKey = key;
+
+      if (prevPictureKey !== nextPictureKey) {
+        try {
+          await backend.post('/accountChange', {
+            user_id: currentUser.uid,
+            author_id: currentUser.uid,
+            change_type: 'Update',
+            old_values: {
+              first_name: gcfUser?.firstName || '',
+              last_name: gcfUser?.lastName || '',
+              email: currentUser?.email || '',
+              picture: prevPictureKey,
+              bio: '',
+            },
+            new_values: {
+              first_name: gcfUser?.firstName || '',
+              last_name: gcfUser?.lastName || '',
+              email: currentUser?.email || '',
+              picture: nextPictureKey,
+              bio: '',
+            },
+            resolved: false,
+            last_modified: new Date().toISOString(),
+          });
+        } catch (changeErr) {
+          console.error('Error logging account change:', changeErr);
+        }
+      }
+
+      setGcfUser((prev) => ({
+        ...prev,
+        pictureKey: nextPictureKey,
+        picture: urlResponse.data.url,
+      }));
+    } catch (err) {
+      console.error('Error saving profile picture:', err);
+    }
+  };
+
+  const handleEdit = () => {
+    const prefLang =
+      gcfUser.preferredLanguage &&
+      isAppLocale(String(gcfUser.preferredLanguage))
+        ? String(gcfUser.preferredLanguage)
+        : 'en';
+    profileEditBaselineRef.current = {
+      firstName: gcfUser.firstName || '',
+      lastName: gcfUser.lastName || '',
+      bio: role === 'Program Director' ? roleSpecificData?.bio || '' : '',
+      pictureKey: gcfUser.pictureKey || null,
+      language: prefLang,
+    };
+    setPendingPictureKey(null);
+    setPendingPicturePreviewUrl(null);
+    setFormData({
+      firstName: gcfUser.firstName || '',
+      lastName: gcfUser.lastName || '',
+      email: currentUser?.email || '',
+      language: prefLang,
+      bio: roleSpecificData?.bio || '',
+    });
+    setIsEditing(true);
+  };
+
+  const handleCancel = () => {
+    setIsEditing(false);
+    setShowPassword(false);
+    setNewPassword('');
+    setPasswordEdited(false);
+    setPendingPictureKey(null);
+    setPendingPicturePreviewUrl(null);
+    profileEditBaselineRef.current = null;
+  };
+
+  const saveProfileEdits = async () => {
+    try {
+      if (role === 'Program Director') {
+        const prefLang =
+          gcfUser.preferredLanguage &&
+          isAppLocale(String(gcfUser.preferredLanguage))
+            ? String(gcfUser.preferredLanguage)
+            : 'en';
+        const base = profileEditBaselineRef.current ?? {
+          firstName: gcfUser?.firstName || '',
+          lastName: gcfUser?.lastName || '',
+          bio: roleSpecificData?.bio || '',
+          pictureKey: gcfUser?.pictureKey || null,
+          language: prefLang,
+        };
+
+        const newBio = formData.bio?.trim() || '';
+        const newPic = pendingPictureKey ?? base.pictureKey;
+        const languageChanged = base.language !== formData.language;
+        const oldValues = {
+          first_name: base.firstName,
+          last_name: base.lastName,
+          email: currentUser?.email || '',
+          picture: base.pictureKey,
+          bio: base.bio,
+        };
+        const newValues = {
+          first_name: formData.firstName,
+          last_name: formData.lastName,
+          email: currentUser?.email || '',
+          picture: newPic,
+          bio: newBio,
+        };
+
+        const hasProfileDiff =
+          JSON.stringify(oldValues) !== JSON.stringify(newValues);
+
+        if (languageChanged) {
+          await backend.patch(
+            `/gcf-users/${currentUser.uid}/preferred-language`,
+            {
+              preferredLanguage: formData.language,
+            }
+          );
+          await i18n.changeLanguage(formData.language);
+          setGcfUser((prev) => ({
+            ...prev,
+            preferredLanguage: formData.language,
+          }));
+        }
+
+        if (!hasProfileDiff) {
+          const now = new Date();
+          const timeStr = now.toLocaleTimeString(i18n.language || 'en', {
+            hour: 'numeric',
+            minute: '2-digit',
+            hour12: true,
+            timeZoneName: 'short',
+          });
+          if (languageChanged) {
+            toast({
+              title: t('profile.savedTitle'),
+              description: t('profile.savedDesc', { time: timeStr }),
+              status: 'success',
+              variant: 'subtle',
+              position: 'bottom-right',
+            });
+          }
+          setIsEditing(false);
+          setShowPassword(false);
+          setPasswordEdited(false);
+          setNewPassword('');
+          setPendingPictureKey(null);
+          setPendingPicturePreviewUrl(null);
+          profileEditBaselineRef.current = null;
+          return;
+        }
+
+        const accountChangeResponse = pendingAccountChange
+          ? await backend.put(`/accountChange/${pendingAccountChange.id}`, {
+              new_values: newValues,
+              last_modified: new Date().toISOString(),
+            })
+          : await backend.post('/accountChange', {
+              user_id: currentUser.uid,
+              author_id: currentUser.uid,
+              change_type: 'Update',
+              old_values: oldValues,
+              new_values: newValues,
+              resolved: false,
+              last_modified: new Date().toISOString(),
+            });
+
+        setGcfUser((prev) => ({
+          ...prev,
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+          ...(pendingPicturePreviewUrl
+            ? { picture: pendingPicturePreviewUrl }
+            : {}),
+        }));
+        setRoleSpecificData((prev) => ({ ...prev, bio: newBio }));
+        setFormData((prev) => ({
+          ...prev,
+          firstName: formData.firstName,
+          lastName: formData.lastName,
+          bio: newBio,
+        }));
+        setPendingAccountChange(accountChangeResponse.data);
+        setPendingPictureKey(null);
+        setPendingPicturePreviewUrl(null);
+        profileEditBaselineRef.current = null;
+        window.dispatchEvent(new Event('profile-updated'));
+
+        toast({
+          title: t('profile.pendingApprovalTitle'),
+          description: t('profile.pendingApprovalDesc'),
+          status: 'info',
+          variant: 'subtle',
+          position: 'bottom-right',
+        });
+
+        setIsEditing(false);
+        setShowPassword(false);
+        setPasswordEdited(false);
+        setNewPassword('');
+        return;
+      }
+
+      const oldValues = {
+        first_name: gcfUser?.firstName || '',
+        last_name: gcfUser?.lastName || '',
+        email: currentUser?.email || '',
+        picture: gcfUser?.pictureKey || null,
+        bio: '',
+      };
+      const newValues = {
+        first_name: formData.firstName,
+        last_name: formData.lastName,
+        email: currentUser?.email || '',
+        picture: gcfUser?.pictureKey || null,
+        bio: '',
+      };
+
+      await backend.put(`/gcf-users/${currentUser.uid}`, {
+        first_name: formData.firstName,
+        last_name: formData.lastName,
+      });
+
+      if (JSON.stringify(oldValues) !== JSON.stringify(newValues)) {
+        try {
+          await backend.post('/accountChange', {
+            user_id: currentUser.uid,
+            author_id: currentUser.uid,
+            change_type: 'Update',
+            old_values: oldValues,
+            new_values: newValues,
+            resolved: false,
+            last_modified: new Date().toISOString(),
+          });
+        } catch (changeErr) {
+          console.error('Error logging account change:', changeErr);
+        }
+      }
+
+      await backend.patch(`/gcf-users/${currentUser.uid}/preferred-language`, {
+        preferredLanguage: formData.language,
+      });
+
+      await i18n.changeLanguage(formData.language);
+      setGcfUser((prev) => ({
+        ...prev,
+        preferredLanguage: formData.language,
+        firstName: formData.firstName,
+        lastName: formData.lastName,
+      }));
+      window.dispatchEvent(new Event('profile-updated'));
+
+      const now = new Date();
+      const timeStr = now.toLocaleTimeString(i18n.language || 'en', {
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+        timeZoneName: 'short',
+      });
+
+      toast({
+        title: t('profile.savedTitle'),
+        description: t('profile.savedDesc', { time: timeStr }),
+        status: 'success',
+        variant: 'subtle',
+        position: 'bottom-right',
+      });
+
+      setIsEditing(false);
+      setShowPassword(false);
+      setPasswordEdited(false);
+      setNewPassword('');
+    } catch (err) {
+      console.error('Error saving profile language:', err);
+      toast({
+        title: t('signup.errorTitle'),
+        description:
+          err.response?.data?.error ??
+          err.message ??
+          t('updates.failedSaveDesc'),
+        status: 'error',
+        variant: 'subtle',
+        position: 'bottom-right',
+      });
+    }
+  };
+
+  const handleSave = async () => {
+    if (
+      !formData.firstName.trim() ||
+      !formData.lastName.trim() ||
+      !formData.email.trim()
+    ) {
+      toast({
+        title: t('profile.invalidInfoTitle'),
+        description: t('profile.invalidInfoDesc'),
+        status: 'error',
+        variant: 'subtle',
+        position: 'bottom-right',
+      });
+      return;
+    }
+
+    if (!currentUser?.uid) return;
+
+    if (passwordEdited && newPassword.length > 0) {
+      if (newPassword.length < 12) {
+        toast({
+          title: t('profile.passwordInvalidTitle'),
+          description: t('profile.passwordMin12Desc'),
+          status: 'error',
+          variant: 'subtle',
+          position: 'bottom-right',
+        });
+        return;
+      }
+      onPasswordModelOpen();
+      return;
+    }
+
+    await saveProfileEdits();
+  };
+
+  const handleInputChange = (field) => (e) => {
+    setFormData((prev) => ({ ...prev, [field]: e.target.value }));
+  };
+
+  const profilePicture =
+    pendingPicturePreviewUrl && role === 'Program Director'
+      ? pendingPicturePreviewUrl
+      : gcfUser?.picture && gcfUser.picture.trim() !== ''
+        ? gcfUser.picture
+        : DEFAULT_PROFILE_IMAGE;
+
+  const pdPending = role === 'Program Director' && !!pendingAccountChange;
+  const ov = pendingAccountChange?.oldValues || {};
+  const nv = pendingAccountChange?.newValues || {};
+  const firstNamePending = pdPending && ov.first_name !== nv.first_name;
+  const lastNamePending = pdPending && ov.last_name !== nv.last_name;
+  const bioPending = pdPending && ov.bio !== nv.bio;
+  const picturePending = pdPending && ov.picture !== nv.picture;
+
+  const handlePasswordChangeSuccess = async () => {
+    onPasswordModelClose();
+    await saveProfileEdits();
+    const now = new Date();
+    const timeStr = now.toLocaleTimeString(i18n.language || 'en', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+      timeZoneName: 'short',
+    });
+    toast({
+      title: t('profile.passwordUpdatedTitle'),
+      description: t('profile.passwordUpdatedDesc', { time: timeStr }),
+      status: 'success',
+      variant: 'subtle',
+      position: 'bottom-right',
+    });
+  };
+
+  return {
+    loading,
+    gcfUser,
+    currentUser,
+    role,
+    roleSpecificData,
+    isEditing,
+    formData,
+    showPassword,
+    setShowPassword,
+    newPassword,
+    setNewPassword,
+    setPasswordEdited,
+    profilePicture,
+    pdPending,
+    firstNamePending,
+    lastNamePending,
+    bioPending,
+    picturePending,
+    localeLabel,
+    handleEdit,
+    handleCancel,
+    handleSave,
+    handleInputChange,
+    handleProfilePictureUpload,
+    handlePasswordChangeSuccess,
+    isOpen,
+    onOpen,
+    onClose,
+    isPasswordModalOpen,
+    onPasswordModelClose,
+  };
+};

--- a/client/src/components/regions/RegionCard.jsx
+++ b/client/src/components/regions/RegionCard.jsx
@@ -9,14 +9,12 @@ import {
   CardBody,
   CardHeader,
   HStack,
-  Icon,
   Text,
 } from '@chakra-ui/react';
 
 import { useBackendContext } from '@/contexts/hooks/useBackendContext';
 import { useTranslation } from 'react-i18next';
 import { GrEdit } from 'react-icons/gr';
-import { MdAccountCircle } from 'react-icons/md';
 
 import { isoCodeToFlagIconCode } from '../../utils/isoCodeToFlagIconCode';
 import { DirectorAvatar } from '../dashboard/ProgramForm/DirectorAvatar';
@@ -24,7 +22,7 @@ import { DirectorAvatar } from '../dashboard/ProgramForm/DirectorAvatar';
 export const RegionCard = ({ region, onEdit, countries }) => {
   const { t } = useTranslation();
   const { backend } = useBackendContext();
-  const [regionalDirectors, setRegionalDirectors] = useState([]);
+  const [regionalDirector, setRegionalDirector] = useState(null);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -32,10 +30,10 @@ export const RegionCard = ({ region, onEdit, countries }) => {
         const res = await backend.get(
           `/regional-directors/region/${region.id}/`
         );
-        const directors = Array.isArray(res.data) ? res.data : [];
-        setRegionalDirectors(directors);
+        const regionalDirector = res.data ? res.data : null;
+        setRegionalDirector(regionalDirector);
       } catch (err) {
-        console.error('Error fetching regional directors:', err);
+        console.error('Error fetching regional director:', err);
       }
     };
 
@@ -67,35 +65,22 @@ export const RegionCard = ({ region, onEdit, countries }) => {
         >
           {t('regions.cardRegionalDirector')}
         </Text>
-        {regionalDirectors.length === 0 ? (
-          <HStack ml="2">
-            <Icon
-              as={MdAccountCircle}
-              mb="1"
-              boxSize={5}
-              color="gray.600"
-            />
-            <Text mb="2">{t('common.na')}</Text>
-          </HStack>
-        ) : (
-          regionalDirectors.map((director) => (
-            <HStack
-              key={director.userId}
-              ml="2"
-            >
-              <DirectorAvatar
-                picture={director?.picture}
-                name={
-                  director ? `${director.firstName} ${director.lastName}` : ''
-                }
-                boxSize="24px"
-              />
-              <Text mb="2">
-                {director.firstName} {director.lastName}
-              </Text>
-            </HStack>
-          ))
-        )}
+        <HStack ml="2">
+          <DirectorAvatar
+            picture={regionalDirector?.picture}
+            name={
+              regionalDirector
+                ? `${regionalDirector.firstName} ${regionalDirector.lastName}`
+                : ''
+            }
+            boxSize="24px"
+          />
+          <Text mb="2">
+            {regionalDirector
+              ? `${regionalDirector.firstName} ${regionalDirector.lastName}`
+              : t('common.na')}
+          </Text>
+        </HStack>
         <Text
           fontSize="xs"
           fontWeight="semibold"
@@ -148,7 +133,7 @@ export const RegionCard = ({ region, onEdit, countries }) => {
           bg: 'teal.500',
         }}
         _groupHover={{ opacity: 1 }}
-        onClick={() => onEdit(region, regionalDirectors)}
+        onClick={() => onEdit(region, regionalDirector)}
         color="teal.500"
         bg="white"
         border="2px solid"

--- a/client/src/components/regions/RegionsForm.jsx
+++ b/client/src/components/regions/RegionsForm.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 
+import { ChevronDownIcon } from '@chakra-ui/icons';
 import {
   AlertDialog,
   AlertDialogBody,
@@ -46,8 +47,8 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
   const [regionalDirectors, setRegionalDirectors] = useState([]);
   const [countries, setCountries] = useState([]);
   const [selectedCountries, setSelectedCountries] = useState([]);
-  const [selectedDirectors, setSelectedDirectors] = useState([]);
-  const [originalDirectorIds, setOriginalDirectorIds] = useState([]);
+  const [selectedDirector, setSelectedDirector] = useState('');
+  const [originalDirectorId, setOriginalDirectorId] = useState('');
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
   const [drawerSize, setDrawerSize] = useState('md');
@@ -81,27 +82,29 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
   useEffect(() => {
     if (region) {
       setRegionName(region.name || '');
-      const fetchRegionDirectors = async () => {
+      const fetchRegionDirector = async () => {
         try {
           const res = await backend.get(
             `/regional-directors/region/${region.id}/`
           );
-          const data = Array.isArray(res.data) ? res.data : [];
-          const ids = data
-            .map((d) => {
-              const match = regionalDirectors.find((rd) => rd.id === d.userId);
-              return match?.id?.toString();
-            })
-            .filter(Boolean);
-          setSelectedDirectors(ids);
-          setOriginalDirectorIds(ids);
+          if (res.data) {
+            const match = regionalDirectors.find(
+              (d) => d.id === res.data.userId
+            );
+            const directorId = match?.id?.toString() ?? '';
+            setSelectedDirector(directorId);
+            setOriginalDirectorId(directorId);
+          } else {
+            setSelectedDirector('');
+            setOriginalDirectorId('');
+          }
         } catch (err) {
-          console.error('Error fetching region directors:', err);
-          setSelectedDirectors([]);
-          setOriginalDirectorIds([]);
+          console.error('Error fetching region director:', err);
+          setSelectedDirector('');
+          setOriginalDirectorId('');
         }
       };
-      fetchRegionDirectors();
+      fetchRegionDirector();
 
       const fetchRegionCountries = async () => {
         try {
@@ -120,8 +123,8 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
       fetchRegionCountries();
     } else {
       setRegionName('');
-      setSelectedDirectors([]);
-      setOriginalDirectorIds([]);
+      setSelectedDirector('');
+      setOriginalDirectorId('');
       setSelectedCountries([]);
     }
   }, [countries, region, regionalDirectors, backend]);
@@ -149,23 +152,18 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
         last_modified: new Date().toISOString(),
       });
 
-      const addedDirectors = selectedDirectors.filter(
-        (id) => !originalDirectorIds.includes(id)
-      );
-      const removedDirectors = originalDirectorIds.filter(
-        (id) => !selectedDirectors.includes(id)
-      );
-
-      await Promise.all([
-        ...addedDirectors.map((id) =>
-          backend.put(`/regional-directors/${id}/region`, {
+      if (selectedDirector !== originalDirectorId) {
+        if (originalDirectorId) {
+          await backend.delete(
+            `/regional-directors/${originalDirectorId}/region/${region.id}`
+          );
+        }
+        if (selectedDirector) {
+          await backend.put(`/regional-directors/${selectedDirector}/region`, {
             region_id: region.id,
-          })
-        ),
-        ...removedDirectors.map((id) =>
-          backend.delete(`/regional-directors/${id}/region/${region.id}`)
-        ),
-      ]);
+          });
+        }
+      }
 
       const existingRes = await backend.get(`/region/${region.id}/countries`);
       const existingCountries = Array.isArray(existingRes.data)
@@ -202,13 +200,11 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
       });
       const newRegionId = newRegion.data.id;
 
-      await Promise.all(
-        selectedDirectors.map((id) =>
-          backend.put(`/regional-directors/${id}/region`, {
-            region_id: newRegionId,
-          })
-        )
-      );
+      if (selectedDirector) {
+        await backend.put(`/regional-directors/${selectedDirector}/region`, {
+          region_id: newRegionId,
+        });
+      }
 
       await Promise.all(
         selectedCountries.map((country) =>
@@ -276,88 +272,66 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
 
             <FormControl>
               <FormLabel>{t('regions.regionalDirector')}</FormLabel>
-              <Flex
-                wrap="wrap"
-                gap={2}
-                mb={2}
-              >
-                {selectedDirectors.map((dirId) => {
-                  const director = regionalDirectors.find(
-                    (d) => d.id.toString() === dirId
-                  );
-                  if (!director) return null;
-                  return (
-                    <Tag
-                      key={dirId}
-                      variant="solid"
-                      colorScheme="teal"
-                    >
-                      <TagLabel
-                        h="30px"
-                        alignItems="center"
-                        display="flex"
-                        justifyContent="center"
-                      >
-                        <HStack spacing={2}>
-                          <DirectorAvatar
-                            picture={director.picture}
-                            name={`${director.firstName} ${director.lastName}`}
-                            boxSize="24px"
-                          />
-                          <Text>
-                            {director.firstName} {director.lastName}
-                          </Text>
-                        </HStack>
-                      </TagLabel>
-                      <TagCloseButton
-                        onClick={() =>
-                          setSelectedDirectors((prev) =>
-                            prev.filter((id) => id !== dirId)
-                          )
-                        }
-                      />
-                    </Tag>
-                  );
-                })}
-              </Flex>
-              <Menu>
+              <Menu matchWidth>
                 <MenuButton
                   as={Button}
                   variant="outline"
-                  size="sm"
+                  width="100%"
+                  textAlign="left"
+                  fontWeight="normal"
+                  rightIcon={<ChevronDownIcon />}
                 >
-                  {t('common.add')}
+                  {(() => {
+                    const dir = regionalDirectors.find(
+                      (d) => String(d.id) === String(selectedDirector)
+                    );
+                    return dir ? (
+                      <HStack spacing={2}>
+                        <DirectorAvatar
+                          picture={dir.picture}
+                          name={`${dir.firstName} ${dir.lastName}`}
+                          boxSize="24px"
+                        />
+                        <Text>
+                          {dir.firstName} {dir.lastName}
+                        </Text>
+                      </HStack>
+                    ) : (
+                      <Text color="gray.400">
+                        {t('regions.directorPlaceholder')}
+                      </Text>
+                    );
+                  })()}
                 </MenuButton>
                 <MenuList
-                  maxH="300px"
+                  maxH="260px"
                   overflowY="auto"
                 >
-                  {regionalDirectors
-                    ?.filter(
-                      (d) => !selectedDirectors.includes(d.id.toString())
-                    )
-                    .map((director) => (
-                      <MenuItem
-                        key={director.id}
-                        onClick={() =>
-                          setSelectedDirectors((prev) => [
-                            ...prev,
-                            director.id.toString(),
-                          ])
-                        }
-                      >
-                        <HStack spacing={2}>
-                          <DirectorAvatar
-                            picture={director.picture}
-                            name={`${director.firstName} ${director.lastName}`}
-                            boxSize="24px"
-                          />
-                          <Text>
-                            {director.firstName} {director.lastName}
-                          </Text>
-                        </HStack>
-                      </MenuItem>
-                    ))}
+                  <MenuItem
+                    value=""
+                    onClick={() => setSelectedDirector('')}
+                  >
+                    <Text color="gray.400">
+                      {t('regions.directorPlaceholder')}
+                    </Text>
+                  </MenuItem>
+                  {regionalDirectors?.map((director) => (
+                    <MenuItem
+                      key={director.id}
+                      onClick={() => setSelectedDirector(String(director.id))}
+                    >
+                      <HStack spacing={2}>
+                        <DirectorAvatar
+                          picture={director.picture}
+                          name={`${director.firstName} ${director.lastName}`}
+                          boxSize="28px"
+                        />
+                        <Text>
+                          {director.firstName} {director.lastName}
+                        </Text>
+                      </HStack>
+                    </MenuItem>
+                  ))}
                 </MenuList>
               </Menu>
             </FormControl>

--- a/client/src/components/regions/RegionsPage.jsx
+++ b/client/src/components/regions/RegionsPage.jsx
@@ -12,8 +12,8 @@ export const RegionsPage = () => {
   const [selectedRegion, setSelectedRegion] = useState(null);
   const [refreshTrigger, setRefreshTrigger] = useState(0);
 
-  const handleEditRegion = (region, regionalDirectors) => {
-    setSelectedRegion({ ...region, regionalDirectors });
+  const handleEditRegion = (region, regionalDirector) => {
+    setSelectedRegion({ ...region, regionalDirector });
     setIsDrawerOpen(true);
   };
 

--- a/client/src/components/updates/ProgramUpdatesTable.jsx
+++ b/client/src/components/updates/ProgramUpdatesTable.jsx
@@ -133,9 +133,7 @@ export const ProgramUpdatesTable = ({
         (update.name || '').toLowerCase().includes(q) ||
         (update.fullName || '').toLowerCase().includes(q) ||
         getProgramUpdateStatusLabel(update, t).toLowerCase().includes(q) ||
-        (formatRelativeDate(update.updatedAt || update.updateDate) || '')
-          .toLowerCase()
-          .includes(q)
+        (formatRelativeDate(update.updatedAt || update.updateDate) || '').toLowerCase().includes(q)
     );
   }, [searchQuery, filteredData, t]);
 

--- a/client/src/components/updates/forms/ReviewProgramUpdate.jsx
+++ b/client/src/components/updates/forms/ReviewProgramUpdate.jsx
@@ -1,0 +1,150 @@
+import {
+  Button,
+  Grid,
+  GridItem,
+  HStack,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Tag,
+  Text,
+} from '@chakra-ui/react';
+
+import { useTranslation } from 'react-i18next';
+
+export const ReviewProgramUpdate = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  changes = [],
+  isLoading,
+}) => {
+  const { t } = useTranslation();
+  const formatDisplayValue = (value) => {
+    if (value === undefined || value === null || value === '') {
+      return t('common.na');
+    }
+
+    if (typeof value === 'boolean') {
+      return value ? t('common.yes') : t('common.no');
+    }
+
+    return value;
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size="3xl"
+      isCentered
+    >
+      <ModalOverlay />
+      <ModalContent
+        borderRadius="md"
+        p={4}
+      >
+        <ModalHeader
+          fontSize="xl"
+          fontWeight="bold"
+          color="gray.800"
+        >
+          {t('common.reviewChanges')}
+        </ModalHeader>
+
+        <ModalBody color="gray.600">
+          <Grid
+            templateColumns="repeat(2, 1fr)"
+            gap={6}
+            rowGap={8}
+          >
+            {changes.map((field, idx) => (
+              <GridItem key={idx}>
+                <Text
+                  fontSize="sm"
+                  color="gray.500"
+                  fontWeight="500"
+                  mb={1}
+                >
+                  {field.label}
+                </Text>
+
+                {field.isTag ? (
+                  <HStack
+                    wrap="wrap"
+                    spacing={2}
+                  >
+                    {field.oldTags?.map((tag, i) => (
+                      <Tag
+                        key={`old-${i}`}
+                        size="md"
+                        colorScheme="red"
+                        textDecoration="line-through"
+                      >
+                        {tag}
+                      </Tag>
+                    ))}
+                    {field.newTags?.map((tag, i) => (
+                      <Tag
+                        key={`new-${i}`}
+                        size="md"
+                        colorScheme="blue"
+                      >
+                        {tag}
+                      </Tag>
+                    ))}
+                  </HStack>
+                ) : (
+                  <HStack
+                    spacing={2}
+                    wrap="wrap"
+                  >
+                    {field.oldValue !== field.newValue &&
+                      field.oldValue !== undefined &&
+                      field.oldValue !== null && (
+                        <Text
+                          textDecoration="line-through"
+                          color="gray.500"
+                        >
+                          {formatDisplayValue(field.oldValue)}
+                        </Text>
+                      )}
+                    <Text color="gray.800">
+                      {formatDisplayValue(field.newValue)}
+                    </Text>
+                  </HStack>
+                )}
+              </GridItem>
+            ))}
+          </Grid>
+        </ModalBody>
+
+        <ModalFooter
+          gap={3}
+          mt={6}
+        >
+          <Button
+            onClick={onClose}
+            bg="gray.100"
+            color="gray.700"
+            _hover={{ bg: 'gray.200' }}
+            isDisabled={isLoading}
+          >
+            {t('common.continueEditing')}
+          </Button>
+
+          <Button
+            colorScheme="teal"
+            onClick={onConfirm}
+            isLoading={isLoading}
+          >
+            {t('common.confirmChanges')}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/client/src/components/updates/forms/account-update-drawer/BaseAccountInfoSection.jsx
+++ b/client/src/components/updates/forms/account-update-drawer/BaseAccountInfoSection.jsx
@@ -1,0 +1,318 @@
+import { useEffect, useState } from 'react';
+
+import {
+  Badge,
+  Box,
+  HStack,
+  Image,
+  Spinner,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+
+import { DiffField } from './DiffField';
+import {
+  DEFAULT_PROFILE_IMAGE,
+  displaySrcForSlot,
+  fetchPictureDisplayUrl,
+  getRoleBadgeProps,
+} from './shared.js';
+
+const RoleDiffField = ({ oldRole, newRole, changeType, t }) => {
+  const isCreation = changeType === 'Creation';
+  const newRoleBadge = getRoleBadgeProps(newRole);
+  const oldRoleBadge = getRoleBadgeProps(oldRole);
+
+  if (isCreation) {
+    if (!newRole) return null;
+    return (
+      <Box>
+        <Text
+          color="teal.500"
+          fontSize="sm"
+          fontWeight="500"
+          mb={1}
+        >
+          {t('common.role')}
+        </Text>
+        <Badge
+          bg={newRoleBadge.bg}
+          color={newRoleBadge.color}
+          borderRadius="md"
+          px={2}
+          py={0.5}
+        >
+          {newRole}
+        </Badge>
+      </Box>
+    );
+  }
+
+  if (!oldRole && !newRole) return null;
+  const hasChange = oldRole !== newRole;
+
+  if (!hasChange) {
+    return (
+      <Box>
+        <Text
+          color="teal.500"
+          fontSize="sm"
+          fontWeight="500"
+          mb={1}
+        >
+          {t('common.role')}
+        </Text>
+        <Badge
+          bg={newRoleBadge.bg}
+          color={newRoleBadge.color}
+          borderRadius="md"
+          px={2}
+          py={0.5}
+        >
+          {newRole || oldRole}
+        </Badge>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Text
+        color="teal.500"
+        fontSize="sm"
+        fontWeight="500"
+        mb={1}
+      >
+        {t('common.role')}
+      </Text>
+      <HStack
+        spacing={2}
+        flexWrap="wrap"
+      >
+        {oldRole ? (
+          <Badge
+            bg={oldRoleBadge.bg}
+            color={oldRoleBadge.color}
+            borderRadius="md"
+            px={2}
+            py={0.5}
+            textDecoration="line-through"
+            opacity={0.75}
+          >
+            {oldRole}
+          </Badge>
+        ) : null}
+        {newRole ? (
+          <Badge
+            bg={newRoleBadge.bg}
+            color={newRoleBadge.color}
+            borderRadius="md"
+            px={2}
+            py={0.5}
+          >
+            {newRole}
+          </Badge>
+        ) : null}
+      </HStack>
+    </Box>
+  );
+};
+
+const ProfileImageDiff = ({ oldKey, newKey, backend, t }) => {
+  const [oldResolved, setOldResolved] = useState(null);
+  const [newResolved, setNewResolved] = useState(null);
+  const [resolving, setResolving] = useState(false);
+
+  const hasOld = Boolean(oldKey && String(oldKey).trim());
+  const hasNew = Boolean(newKey && String(newKey).trim());
+
+  useEffect(() => {
+    if (!backend) {
+      setOldResolved(null);
+      setNewResolved(null);
+      setResolving(false);
+      return;
+    }
+
+    if (!hasOld && !hasNew) {
+      setOldResolved(null);
+      setNewResolved(null);
+      setResolving(false);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      setResolving(true);
+      try {
+        const [o, n] = await Promise.all([
+          hasOld
+            ? fetchPictureDisplayUrl(backend, oldKey)
+            : Promise.resolve(null),
+          hasNew
+            ? fetchPictureDisplayUrl(backend, newKey)
+            : Promise.resolve(null),
+        ]);
+        if (!cancelled) {
+          setOldResolved(o);
+          setNewResolved(n);
+        }
+      } finally {
+        if (!cancelled) setResolving(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [backend, oldKey, newKey, hasOld, hasNew]);
+
+  const label = (
+    <Text
+      color="teal.500"
+      fontSize="sm"
+      fontWeight="500"
+      mb={2}
+    >
+      {t('common.profilePicture')}
+    </Text>
+  );
+
+  if (resolving) {
+    return (
+      <Box>
+        {label}
+        <Spinner size="md" />
+      </Box>
+    );
+  }
+
+  const displayOld = displaySrcForSlot(hasOld, oldResolved);
+  const displayNew = displaySrcForSlot(hasNew, newResolved);
+
+  const unchanged =
+    hasOld && hasNew && String(oldKey).trim() === String(newKey).trim();
+
+  if (!hasOld && !hasNew) {
+    return (
+      <Box>
+        {label}
+        <Image
+          src={DEFAULT_PROFILE_IMAGE}
+          boxSize="120px"
+          borderRadius="full"
+          objectFit="cover"
+          alt={t('common.profilePicture')}
+        />
+      </Box>
+    );
+  }
+
+  if (unchanged) {
+    const single = displayNew || displayOld || DEFAULT_PROFILE_IMAGE;
+    return (
+      <Box>
+        {label}
+        <Image
+          src={single}
+          boxSize="120px"
+          borderRadius="full"
+          objectFit="cover"
+          alt={t('common.profilePicture')}
+        />
+      </Box>
+    );
+  }
+
+  const oldSrc = hasOld ? displayOld : DEFAULT_PROFILE_IMAGE;
+  const newSrc = hasNew ? displayNew : DEFAULT_PROFILE_IMAGE;
+
+  return (
+    <Box>
+      {label}
+      <HStack
+        spacing={4}
+        align="flex-start"
+      >
+        <VStack
+          spacing={1}
+          align="center"
+        >
+          <Image
+            src={oldSrc}
+            boxSize="120px"
+            borderRadius="full"
+            objectFit="cover"
+            alt={t('common.oldProfile')}
+            {...(hasOld
+              ? {
+                  opacity: 0.85,
+                  sx: { WebkitFilter: 'grayscale(35%)' },
+                }
+              : {})}
+          />
+          <Text
+            fontSize="xs"
+            color="gray.600"
+            fontWeight="500"
+          >
+            {t('common.diffLabelOld')}
+          </Text>
+        </VStack>
+        <VStack
+          spacing={1}
+          align="center"
+        >
+          <Image
+            src={newSrc}
+            boxSize="120px"
+            borderRadius="full"
+            objectFit="cover"
+            alt={t('common.newProfile')}
+          />
+          <Text
+            fontSize="xs"
+            color="gray.600"
+            fontWeight="500"
+          >
+            {t('common.diffLabelNew')}
+          </Text>
+        </VStack>
+      </HStack>
+    </Box>
+  );
+};
+
+export const BaseAccountInfoSection = ({ fields, changeType, backend, t }) => (
+  <>
+    <ProfileImageDiff
+      oldKey={fields.oldPic}
+      newKey={fields.newPic}
+      backend={backend}
+      t={t}
+    />
+    <DiffField
+      label={t('common.firstName')}
+      oldValue={fields.oldFirst}
+      newValue={fields.newFirst}
+      changeType={changeType}
+    />
+    <DiffField
+      label={t('common.lastName')}
+      oldValue={fields.oldLast}
+      newValue={fields.newLast}
+      changeType={changeType}
+    />
+    <DiffField
+      label={t('common.email')}
+      oldValue={fields.oldEmail}
+      newValue={fields.newEmail}
+      changeType={changeType}
+    />
+    <RoleDiffField
+      oldRole={fields.oldRole}
+      newRole={fields.newRole}
+      changeType={changeType}
+      t={t}
+    />
+  </>
+);

--- a/client/src/components/updates/forms/account-update-drawer/DiffField.jsx
+++ b/client/src/components/updates/forms/account-update-drawer/DiffField.jsx
@@ -1,0 +1,70 @@
+import { Box, HStack, Text } from '@chakra-ui/react';
+
+export const DiffField = ({
+  label,
+  oldValue,
+  newValue,
+  changeType,
+  hasChangeOverride,
+}) => {
+  const oldStr = oldValue ?? '';
+  const newStr = newValue ?? '';
+  const isCreation = changeType === 'Creation';
+
+  if (isCreation) {
+    if (!newStr) return null;
+    return (
+      <Box>
+        <Text
+          color="teal.500"
+          fontSize="sm"
+          fontWeight="500"
+          mb={1}
+        >
+          {label}
+        </Text>
+        <Text>{newStr}</Text>
+      </Box>
+    );
+  }
+
+  if (!oldStr && !newStr && hasChangeOverride !== true) return null;
+
+  const hasChange =
+    typeof hasChangeOverride === 'boolean'
+      ? hasChangeOverride
+      : String(oldStr) !== String(newStr);
+
+  return (
+    <Box>
+      <Text
+        color="teal.500"
+        fontSize="sm"
+        fontWeight="500"
+        mb={1}
+      >
+        {label}
+      </Text>
+      {hasChange ? (
+        <HStack
+          spacing={2}
+          align="baseline"
+          flexWrap="wrap"
+        >
+          {oldStr ? (
+            <Text
+              as="span"
+              textDecoration="line-through"
+              color="gray.500"
+            >
+              {oldStr}
+            </Text>
+          ) : null}
+          {newStr ? <Text as="span">{newStr}</Text> : null}
+        </HStack>
+      ) : (
+        <Text>{newStr || oldStr}</Text>
+      )}
+    </Box>
+  );
+};

--- a/client/src/components/updates/forms/account-update-drawer/RoleSpecificDetails.jsx
+++ b/client/src/components/updates/forms/account-update-drawer/RoleSpecificDetails.jsx
@@ -1,0 +1,54 @@
+import { DiffField } from './DiffField';
+
+export const RoleSpecificDetails = ({
+  fields,
+  changeType,
+  roleDiffers,
+  programOldDisplay,
+  regionOldDisplay,
+  bioOldDisplay,
+  newRoleNorm,
+  t,
+}) => {
+  if (newRoleNorm === 'Program Director') {
+    return (
+      <>
+        <DiffField
+          label={t('common.program')}
+          oldValue={programOldDisplay}
+          newValue={fields.newProg}
+          changeType={changeType}
+          hasChangeOverride={roleDiffers ? undefined : fields.progById}
+        />
+        <DiffField
+          label={t('common.biography')}
+          oldValue={bioOldDisplay}
+          newValue={fields.newBio}
+          changeType={changeType}
+        />
+      </>
+    );
+  }
+
+  if (newRoleNorm === 'Regional Director') {
+    return (
+      <>
+        <DiffField
+          label={t('common.region')}
+          oldValue={regionOldDisplay}
+          newValue={fields.newReg}
+          changeType={changeType}
+          hasChangeOverride={roleDiffers ? undefined : fields.regById}
+        />
+        <DiffField
+          label={t('common.biography')}
+          oldValue={bioOldDisplay}
+          newValue={fields.newBio}
+          changeType={changeType}
+        />
+      </>
+    );
+  }
+
+  return null;
+};

--- a/client/src/components/updates/forms/account-update-drawer/shared.js
+++ b/client/src/components/updates/forms/account-update-drawer/shared.js
@@ -1,0 +1,159 @@
+export const DEFAULT_PROFILE_IMAGE = '/default-profile.png';
+
+export const getRoleBadgeProps = (role) => {
+  switch (role) {
+    case 'Program Director':
+      return { bg: 'teal.100', color: 'teal.800' };
+    case 'Regional Director':
+      return { bg: 'teal.400', color: 'white' };
+    case 'Admin':
+    case 'Super Admin':
+      return { bg: 'teal.700', color: 'white' };
+    default:
+      return { bg: 'gray.200', color: 'gray.800' };
+  }
+};
+
+export const ACCOUNT_CHANGE_DEFAULTS = {
+  first_name: '',
+  last_name: '',
+  email: '',
+  picture: '',
+  role: '',
+  program: '',
+  region: '',
+  bio: '',
+};
+
+export const normalizeAccountSnapshot = (snap) => {
+  if (!snap || typeof snap !== 'object') {
+    return { ...ACCOUNT_CHANGE_DEFAULTS };
+  }
+  const { password: _omitPwd, ...rest } = snap;
+  return {
+    ...ACCOUNT_CHANGE_DEFAULTS,
+    ...rest,
+  };
+};
+
+export const isBlank = (v) => v == null || String(v).trim() === '';
+
+export const valueOrFallback = (primary, fallback) =>
+  isBlank(primary) ? (fallback ?? '') : primary;
+
+export const firstNonBlank = (a, b) => {
+  if (!isBlank(a)) return a;
+  if (!isBlank(b)) return b;
+  return '';
+};
+
+export const pickStr = (snap, camelKey, snakeKey) => {
+  if (!snap || typeof snap !== 'object') return '';
+  const v =
+    snakeKey !== undefined
+      ? firstNonBlank(snap[camelKey], snap[snakeKey])
+      : snap[camelKey];
+  if (v == null) return '';
+  return String(v).trim();
+};
+
+export const programName = (snap) => {
+  const list = snap?.programs ?? snap?.Programs;
+  if (!Array.isArray(list) || list.length === 0) return '';
+  const p = list[0];
+  return p?.name != null ? String(p.name).trim() : '';
+};
+
+export const regionName = (snap) => {
+  const list = snap?.regions ?? snap?.Regions;
+  if (!Array.isArray(list) || list.length === 0) return '';
+  const r = list[0];
+  return r?.name != null ? String(r.name).trim() : '';
+};
+
+export const resolveProgramDisplay = (snap, idToName) => {
+  const n = programName(snap);
+  if (n) return n;
+  const direct = snap?.program;
+  if (typeof direct === 'string' && direct.trim()) return direct.trim();
+  const id = snap?.programId ?? snap?.program_id ?? snap?.programs?.[0]?.id;
+  if (id == null || id === '') return '';
+  const mapped = idToName[String(id)];
+  return mapped && mapped.trim() ? mapped : String(id);
+};
+
+export const resolveRegionDisplay = (snap, idToName) => {
+  const n = regionName(snap);
+  if (n) return n;
+  const direct = snap?.region;
+  if (typeof direct === 'string' && direct.trim()) return direct.trim();
+  const id = snap?.regionId ?? snap?.region_id ?? snap?.regions?.[0]?.id;
+  if (id == null || id === '') return '';
+  const mapped = idToName[String(id)];
+  return mapped && mapped.trim() ? mapped : String(id);
+};
+
+export const programIdKey = (snap) => {
+  if (!snap || typeof snap !== 'object') return '';
+  const id = snap.programId ?? snap.program_id ?? snap.programs?.[0]?.id;
+  return id == null || id === '' ? '' : String(id);
+};
+
+export const regionIdKey = (snap) => {
+  if (!snap || typeof snap !== 'object') return '';
+  const id = snap.regionId ?? snap.region_id ?? snap.regions?.[0]?.id;
+  return id == null || id === '' ? '' : String(id);
+};
+
+export const isDirectImageUrl = (s) =>
+  typeof s === 'string' && /^https?:\/\//i.test(s.trim());
+
+export const fetchPictureDisplayUrl = async (backend, keyOrUrl) => {
+  if (!keyOrUrl || !String(keyOrUrl).trim()) return null;
+  const raw = String(keyOrUrl).trim();
+  if (isDirectImageUrl(raw)) return raw;
+  try {
+    const { data } = await backend.get(
+      `/images/url/${encodeURIComponent(raw)}`
+    );
+    if (data?.success === false) return null;
+    const url = data?.url != null ? String(data.url).trim() : '';
+    return url || null;
+  } catch (err) {
+    console.error('Error fetching profile image URL:', err);
+    return null;
+  }
+};
+
+export const displaySrcForSlot = (hadKey, resolvedUrl) => {
+  if (!hadKey) return '';
+  if (resolvedUrl && String(resolvedUrl).trim() !== '') {
+    return String(resolvedUrl).trim();
+  }
+  return DEFAULT_PROFILE_IMAGE;
+};
+
+export const pictureUrl = (snap) => {
+  if (!snap || typeof snap !== 'object') return '';
+  const u = firstNonBlank(
+    firstNonBlank(
+      firstNonBlank(snap.picture, snap.profilePicture),
+      snap.profile_image
+    ),
+    snap.photoUrl
+  );
+  return typeof u === 'string' && u.trim() ? u.trim() : '';
+};
+
+export const auditPictureKey = (rawValues) =>
+  pictureUrl(normalizeAccountSnapshot(rawValues));
+
+export const bioText = (snap) => {
+  if (!snap || typeof snap !== 'object') return '';
+  const b = firstNonBlank(
+    firstNonBlank(snap.biography, snap.bio),
+    snap.biographyText
+  );
+  if (isBlank(b)) return '';
+  return String(b).trim();
+};

--- a/client/src/utils/formatDate.js
+++ b/client/src/utils/formatDate.js
@@ -1,0 +1,137 @@
+function parseExactDateOnly(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value).trim());
+  if (!match) return null;
+
+  const [, year, month, day] = match;
+  const expectedYear = Number(year);
+  const expectedMonth = Number(month);
+  const expectedDay = Number(day);
+  const date = new Date(expectedYear, expectedMonth - 1, expectedDay);
+
+  if (
+    date.getFullYear() !== expectedYear ||
+    date.getMonth() + 1 !== expectedMonth ||
+    date.getDate() !== expectedDay
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+const ISO_LIKE_TIMESTAMP =
+  /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,6})?)?$/;
+const HAS_TIMEZONE_SUFFIX = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+function normalizeTimestampString(value) {
+  const trimmed = String(value).trim();
+  if (!ISO_LIKE_TIMESTAMP.test(trimmed)) return trimmed;
+
+  const normalized = trimmed.replace(' ', 'T');
+  return HAS_TIMEZONE_SUFFIX.test(normalized) ? normalized : `${normalized}Z`;
+}
+
+/**
+ * Format a date as "Mon YYYY" (e.g. "Apr 2026").
+ * Returns 'N/A' for missing or invalid dates.
+ */
+export function formatMonthYear(dateString) {
+  if (!dateString) return 'N/A';
+
+  const isDateOnlyString = /^\d{4}-\d{2}-\d{2}$/.test(
+    String(dateString).trim()
+  );
+  const exactDateOnly = parseExactDateOnly(dateString);
+  if (isDateOnlyString && !exactDateOnly) return 'N/A';
+
+  const date = exactDateOnly ?? new Date(normalizeTimestampString(dateString));
+  if (isNaN(date.getTime())) return 'N/A';
+
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    year: 'numeric',
+  });
+}
+
+/**
+ * Smart relative date display:
+ *  - Today → time only (e.g. "3:45 PM")
+ *  - This year → short date (e.g. "Apr 18")
+ *  - Older → numeric date (e.g. "04/18/24")
+ *
+ * Normalises raw DB timestamps that may lack a timezone suffix.
+ */
+export function formatRelativeDate(dateStr) {
+  if (!dateStr) return '';
+
+  const safeDateString = normalizeTimestampString(dateStr);
+
+  const d = new Date(safeDateString);
+  if (isNaN(d.getTime())) return dateStr;
+
+  const now = new Date();
+  const isToday =
+    d.getDate() === now.getDate() &&
+    d.getMonth() === now.getMonth() &&
+    d.getFullYear() === now.getFullYear();
+
+  const isThisYear = d.getFullYear() === now.getFullYear();
+
+  if (isToday) {
+    return d.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }
+
+  if (isThisYear) {
+    return d.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+    });
+  }
+
+  return d.toLocaleDateString('en-US', {
+    month: '2-digit',
+    day: '2-digit',
+    year: '2-digit',
+  });
+}
+
+/**
+ * Display-friendly date for update detail views.
+ *  - Date-only strings (YYYY-MM-DD) → "Sat, Apr 18, 2026"
+ *  - Timestamps → "Sat, Apr 18, 2026, 3:45 PM"
+ *
+ * Returns the original string when parsing fails.
+ */
+export function formatUpdateDisplayDate(value) {
+  if (value === null || value === undefined || value === '') return '';
+  const s = String(value).trim();
+
+  const isDateOnlyString = /^\d{4}-\d{2}-\d{2}$/.test(s);
+  const exactDateOnly = parseExactDateOnly(s);
+  if (isDateOnlyString) {
+    if (!exactDateOnly) return s;
+
+    return exactDateOnly.toLocaleDateString(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
+  const dt = new Date(normalizeTimestampString(s));
+  if (Number.isNaN(dt.getTime())) return s;
+
+  return dt.toLocaleString(undefined, {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+}

--- a/server/db/schema/file_change.sql
+++ b/server/db/schema/file_change.sql
@@ -1,0 +1,14 @@
+/* table for file changes, primarily adding PDFs to programs */
+CREATE TABLE IF NOT EXISTS file_change (
+    id BIGSERIAL PRIMARY KEY,
+    update_id BIGINT NOT NULL,
+    s3_key VARCHAR(1024) NOT NULL,
+    file_name VARCHAR(255) NOT NULL,
+    file_type VARCHAR(50) NOT NULL,
+    description TEXT,
+    status TEXT DEFAULT 'Unread',
+    CONSTRAINT fk_program_update
+        FOREIGN KEY(update_id)
+            REFERENCES program_update(id)
+            ON DELETE CASCADE
+);

--- a/server/db/schema/indexes.sql
+++ b/server/db/schema/indexes.sql
@@ -1,0 +1,14 @@
+-- Used in JOIN: program p → country c ON c.id = p.country
+CREATE INDEX IF NOT EXISTS idx_program_country ON program(country);
+
+-- Used in JOIN: country c → region r ON r.id = c.region_id
+CREATE INDEX IF NOT EXISTS idx_country_region_id ON country(region_id);
+
+-- Used in JOIN + aggregation subqueries: program_update pu ON pu.program_id = p.id
+CREATE INDEX IF NOT EXISTS idx_program_update_program_id ON program_update(program_id);
+
+-- Used in aggregation JOIN: enrollment_change ec ON ec.update_id = pu.id
+CREATE INDEX IF NOT EXISTS idx_enrollment_change_update_id ON enrollment_change(update_id);
+
+-- Used in aggregation JOIN: instrument_change ic ON ic.update_id = pu.id
+CREATE INDEX IF NOT EXISTS idx_instrument_change_update_id ON instrument_change(update_id);

--- a/server/db/schema/instrument_change_photo.sql
+++ b/server/db/schema/instrument_change_photo.sql
@@ -1,0 +1,14 @@
+CREATE TABLE public.instrument_change_photo (
+  id bigserial NOT NULL PRIMARY KEY,
+  instrument_change_id bigint NOT NULL,
+  s3_key character varying(1024) NOT NULL,
+  file_name character varying(255) NOT NULL,
+  file_type character varying(50) NOT NULL,
+  description text NULL
+);
+
+ALTER TABLE public.instrument_change_photo
+ADD CONSTRAINT fk_instrument_change
+    FOREIGN KEY(instrument_change_id)
+        REFERENCES instrument_change(id)
+        ON DELETE CASCADE;

--- a/server/routes/accountChange.js
+++ b/server/routes/accountChange.js
@@ -1,0 +1,291 @@
+import { keysToCamel } from '@/common/utils';
+import { getAuthenticatedUser } from '@/middleware';
+import express from 'express';
+
+import { db } from '../db/db-pgp';
+
+const RESOLVER_ROLES = new Set(['Admin', 'Super Admin', 'Regional Director']);
+
+function snapshotFromJsonb(val) {
+  if (val === null || val === undefined) return null;
+  if (typeof val === 'object') return val;
+  if (typeof val === 'string') {
+    try {
+      return JSON.parse(val);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+async function applyPendingProgramDirectorProfile(t, row) {
+  const nv = snapshotFromJsonb(row.new_values);
+  if (!nv || typeof nv !== 'object') return;
+
+  const uid = row.user_id;
+  const firstName = nv.first_name ?? nv.firstName;
+  const lastName = nv.last_name ?? nv.lastName;
+  const picture = Object.hasOwn(nv, 'picture') ? nv.picture : undefined;
+  const bio = nv.bio ?? nv.biography;
+  const prefLang = nv.preferred_language ?? nv.preferredLanguage;
+
+  const gcfSets = [];
+  const gcfVals = [];
+  let i = 1;
+  if (firstName !== undefined) {
+    gcfSets.push(`first_name = $${i++}`);
+    gcfVals.push(firstName);
+  }
+  if (lastName !== undefined) {
+    gcfSets.push(`last_name = $${i++}`);
+    gcfVals.push(lastName);
+  }
+  if (picture !== undefined) {
+    gcfSets.push(`picture = $${i++}`);
+    gcfVals.push(picture);
+  }
+  if (prefLang !== undefined) {
+    gcfSets.push(`preferred_language = $${i++}`);
+    gcfVals.push(prefLang);
+  }
+  if (gcfSets.length) {
+    gcfVals.push(uid);
+    await t.none(
+      `UPDATE gcf_user SET ${gcfSets.join(', ')} WHERE id = $${i}`,
+      gcfVals
+    );
+  }
+  if (bio !== undefined) {
+    await t.none(
+      `UPDATE program_director SET bio = $1 WHERE user_id = $2`,
+      [bio, uid]
+    );
+  }
+}
+
+const accountChangeRouter = express.Router();
+accountChangeRouter.use(express.json());
+
+accountChangeRouter.get('/', async (req, res) => {
+  try {
+    const { userId, resolved } = req.query;
+    const conditions = [];
+    const params = [];
+    let i = 1;
+
+    if (userId) {
+      conditions.push(`ac.user_id = $${i++}`);
+      params.push(userId);
+    }
+    if (resolved !== undefined) {
+      conditions.push(`ac.resolved = $${i++}`);
+      params.push(resolved === 'true');
+    }
+
+    const whereClause = conditions.length
+      ? `WHERE ${conditions.join(' AND ')}`
+      : '';
+
+    const data = await db.query(
+      `SELECT
+        ac.*,
+        u.first_name AS author_first_name,
+        u.last_name AS author_last_name,
+        u.picture AS author_picture
+      FROM account_change ac
+      LEFT JOIN gcf_user u ON ac.author_id = u.id
+      ${whereClause}
+      ORDER BY ac.last_modified DESC`,
+      params
+    );
+
+    res.status(200).json(keysToCamel(data));
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+accountChangeRouter.get('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const accountChange = await db.query(
+      `SELECT 
+        ac.*, 
+        u.first_name AS author_first_name,
+        u.last_name AS author_last_name,
+        u.picture AS author_picture
+      FROM account_change ac
+      LEFT JOIN gcf_user u ON ac.author_id = u.id
+      WHERE ac.id = $1`,
+      [id]
+    );
+
+    if (accountChange.length === 0) {
+      return res.status(404).send('Item not found');
+    }
+
+    res.status(200).json(keysToCamel(accountChange[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+accountChangeRouter.post('/', async (req, res) => {
+  try {
+    const {
+      user_id,
+      author_id,
+      change_type,
+      old_values,
+      new_values,
+      resolved,
+      last_modified,
+    } = req.body;
+
+    const newAccountChange = await db.query(
+      `INSERT INTO account_change (user_id, author_id, change_type, old_values, new_values, resolved, last_modified)
+      VALUES ($1, $2, $3, $4::jsonb, $5::jsonb, COALESCE($6, FALSE), $7)
+      RETURNING *`,
+      [
+        user_id,
+        author_id,
+        change_type,
+        old_values ? JSON.stringify(old_values) : null,
+        new_values ? JSON.stringify(new_values) : null,
+        resolved,
+        last_modified,
+      ]
+    );
+    res.status(201).json(keysToCamel(newAccountChange[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+accountChangeRouter.put('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const {
+      user_id,
+      author_id,
+      change_type,
+      old_values,
+      new_values,
+      resolved,
+      last_modified,
+    } = req.body;
+
+    const updatedRow = await db.tx(async (t) => {
+      const existingRows = await t.manyOrNone(
+        'SELECT * FROM account_change WHERE id = $1 FOR UPDATE',
+        [id]
+      );
+      const existing = existingRows[0];
+      if (!existing) {
+        return null;
+      }
+
+      const incomingResolved =
+        resolved !== undefined ? resolved : existing.resolved;
+      const wasUnresolved = !existing.resolved;
+      const becomesResolved = wasUnresolved && incomingResolved === true;
+
+      if (becomesResolved) {
+        const selfInitiated =
+          existing.user_id &&
+          existing.author_id &&
+          String(existing.user_id) === String(existing.author_id);
+        const isUpdate = String(existing.change_type) === 'Update';
+
+        if (selfInitiated && isUpdate) {
+          const target = await t.oneOrNone(
+            'SELECT role FROM gcf_user WHERE id = $1',
+            [existing.user_id]
+          );
+          const targetIsPd =
+            target && String(target.role) === 'Program Director';
+
+          if (targetIsPd) {
+            let authUser;
+            try {
+              authUser = await getAuthenticatedUser(req, res);
+            } catch {
+              throw new Error('RESOLVE_UNAUTHORIZED');
+            }
+            if (!RESOLVER_ROLES.has(String(authUser.role))) {
+              throw new Error('RESOLVE_FORBIDDEN');
+            }
+            await applyPendingProgramDirectorProfile(t, existing);
+          }
+        }
+      }
+
+      const updated = await t.manyOrNone(
+        `UPDATE account_change SET user_id = COALESCE($1, user_id),
+        author_id = COALESCE($2, author_id),
+        change_type = COALESCE($3, change_type),
+        old_values = COALESCE($4::jsonb, old_values),
+        new_values = COALESCE($5::jsonb, new_values),
+        resolved = COALESCE($6, resolved),
+        last_modified = COALESCE($7, last_modified)
+        WHERE id = $8
+        RETURNING *;`,
+        [
+          user_id,
+          author_id,
+          change_type,
+          old_values ? JSON.stringify(old_values) : null,
+          new_values ? JSON.stringify(new_values) : null,
+          resolved,
+          last_modified,
+          id,
+        ]
+      );
+      return updated[0] ?? null;
+    });
+
+    if (!updatedRow) {
+      return res.status(404).send('Item not found');
+    }
+
+    res.status(200).json(keysToCamel(updatedRow));
+  } catch (err) {
+    if (err?.message === 'RESOLVE_UNAUTHORIZED') {
+      return res.status(401).send('Unauthorized');
+    }
+    if (err?.message === 'RESOLVE_FORBIDDEN') {
+      return res
+        .status(403)
+        .send(
+          'Only an admin or regional director can approve this profile update.'
+        );
+    }
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+accountChangeRouter.delete('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const deletedAccountChange = await db.query(
+      `DELETE FROM account_change WHERE id = $1 RETURNING *`,
+      [id]
+    );
+
+    if (deletedAccountChange.length === 0) {
+      return res.status(404).send('Item not found');
+    }
+
+    res.status(200).json(keysToCamel(deletedAccountChange[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+export { accountChangeRouter };

--- a/server/routes/fileChange.js
+++ b/server/routes/fileChange.js
@@ -1,0 +1,120 @@
+import { keysToCamel } from '@/common/utils';
+import express from 'express';
+
+import { db } from '../db/db-pgp';
+import { deleteFromS3 } from '../common/s3';
+
+const fileChangeRouter = express.Router();
+fileChangeRouter.use(express.json());
+
+fileChangeRouter.post('/', async (req, res) => {
+  try {
+    const { update_id, s3_key, file_name, file_type } = req.body;
+    const newFileChange = await db.query(
+      `INSERT INTO file_change (update_id, s3_key, file_name, file_type) VALUES ($1, $2, $3, $4) RETURNING *`,
+      [update_id, s3_key, file_name, file_type]
+    );
+    res.status(201).json(keysToCamel(newFileChange[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+/** All `file_change` rows linked to a program (via `program_update`). */
+fileChangeRouter.get('/program/:programId', async (req, res) => {
+  try {
+    const { programId } = req.params;
+
+    const result = await db.query(
+      `
+      SELECT fc.id, fc.s3_key, fc.file_name, fc.file_type, fc.description
+      FROM file_change fc
+      JOIN program_update pu ON fc.update_id = pu.id
+      WHERE pu.program_id = $1;
+      `,
+      [programId]
+    );
+
+    const files = result.map((row) => ({
+      id: row.id,
+      s3_key: row.s3_key,
+      file_name: row.file_name,
+      file_type: row.file_type,
+      description: row.description,
+    }));
+
+    res.status(200).json(files);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+async function fetchUserFiles(userId) {
+  const result = await db.query(
+    `
+    SELECT
+      fc.id,
+      fc.s3_key,
+      fc.file_name,
+      fc.file_type,
+      fc.description,
+      fc.status,
+      p.id as program_id,
+      p.name as program_name
+    FROM program_director pd
+    JOIN program p ON pd.program_id = p.id
+    LEFT JOIN program_update pu ON pu.program_id = pd.program_id
+    LEFT JOIN file_change fc ON fc.update_id = pu.id
+    WHERE pd.user_id = $1
+    ORDER BY fc.id DESC NULLS LAST
+    `,
+    [userId]
+  );
+
+  if (!result || result.length === 0) {
+    return { files: [], programName: null, programId: null };
+  }
+
+  const fileItems = result.filter((row) => row.id !== null);
+
+  return {
+    files: keysToCamel(fileItems),
+    programName: result[0].program_name,
+    programId: result[0].program_id,
+  };
+}
+
+fileChangeRouter.get('/:userId/files', async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const data = await fetchUserFiles(userId);
+    res.status(200).json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+fileChangeRouter.delete('/:id', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const deletedFileChange = await db.query(
+      `DELETE FROM file_change WHERE id = $1 RETURNING *`,
+      [id]
+    );
+
+    if (deletedFileChange.length === 0) {
+      return res.status(404).send('Item not found');
+    }
+
+    await deleteFromS3(deletedFileChange[0].s3_key);
+    res.status(200).json(keysToCamel(deletedFileChange[0]));
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Internal Server Error');
+  }
+});
+
+export { fileChangeRouter };

--- a/server/routes/instrumentChangePhoto.js
+++ b/server/routes/instrumentChangePhoto.js
@@ -1,0 +1,74 @@
+import { keysToCamel } from '@/common/utils';
+import express from 'express';
+
+import { db } from '../db/db-pgp';
+import { deleteFromS3 } from '../common/s3';
+
+const instrumentChangePhotoRouter = express.Router();
+instrumentChangePhotoRouter.use(express.json());
+
+instrumentChangePhotoRouter.post('/', async (req, res) => {
+    try {
+        const { instrument_change_id, s3_key, file_name, file_type } = req.body;
+
+        if (!instrument_change_id || !s3_key || !file_name || !file_type) {
+            return res.status(400).send('Missing required fields for media.');
+        }
+
+        if (isNaN(instrument_change_id)) {
+            return res.status(400).send('Invalid ID format.');
+        }
+
+        const newInstrumentChangePhoto = await db.query(
+            `INSERT INTO instrument_change_photo (instrument_change_id, s3_key, file_name, file_type) VALUES ($1, $2, $3, $4) RETURNING *`,
+            [instrument_change_id, s3_key, file_name, file_type]
+        );
+        res.status(201).json(keysToCamel(newInstrumentChangePhoto[0]));
+    }
+    catch (err) {
+        console.error(err);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
+instrumentChangePhotoRouter.get('/instrument-change/:instrumentChangeId', async (req, res) => {
+    try {
+        const { instrumentChangeId } = req.params;
+        const data = await db.query(
+            `SELECT * FROM instrument_change_photo WHERE instrument_change_id = $1`,
+            [instrumentChangeId]
+        );
+        res.status(200).json(keysToCamel(data));
+    } catch (err) {
+        console.error(err);
+        res.status(500).send('Internal Server Error');
+    }
+});
+
+instrumentChangePhotoRouter.delete('/:id', async (req, res) => {
+    try {
+        const { id } = req.params;
+
+        if (isNaN(id)) {
+            return res.status(400).send('Invalid ID format.');
+        }
+
+        const deletedInstrumentChangePhoto = await db.query(
+            `DELETE FROM instrument_change_photo WHERE id = $1 RETURNING *`,
+            [id]
+        );
+
+        if (deletedInstrumentChangePhoto.length === 0) {
+            return res.status(404).send('Instrument change photo not found');
+        }
+
+        await deleteFromS3(deletedInstrumentChangePhoto[0].s3_key);
+        res.status(200).json(keysToCamel(deletedInstrumentChangePhoto[0]));
+    }
+    catch (err) {
+        console.error(err)
+        res.status(500).send('Internal Server Error');
+    }
+});
+
+export { instrumentChangePhotoRouter };

--- a/server/routes/regionalDirector.js
+++ b/server/routes/regionalDirector.js
@@ -22,14 +22,16 @@ regionalDirectorRouter.get('/all', async (req, res) => {
 regionalDirectorRouter.get('/region/:region_id', async (req, res) => {
   try {
     const { region_id } = req.params;
-    const directors = await db.query(
+    const director = await db.query(
       `SELECT rd.*, u.first_name, u.last_name, u.picture
        FROM regional_director rd
        JOIN gcf_user u ON u.id = rd.user_id
-       WHERE rd.region_id = $1`,
+       WHERE rd.region_id = $1
+       LIMIT 1`,
       [region_id]
     );
-    res.status(200).json(keysToCamel(directors));
+    if (!director?.length) return res.status(200).json(null);
+    res.status(200).json(keysToCamel(director[0]));
   } catch (err) {
     console.error('Error in /region/:region_id', err);
     res.status(500).json({ error: 'Internal server error' });


### PR DESCRIPTION
Reverts ctc-uci/gcf#132

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the multi–Regional Director change and returns regions to a single director model across UI and API. Also adds new profile/account management and program media features with supporting backend routes and tables.

- **New Features**
  - Regions: revert to a single Regional Director per region; Regions UI now uses a single select; `/regional-directors/region/:region_id` returns one record.
  - Accounts/Profile: new account drawer and review modals for pending changes; new profile page with edit/password flows; backend `accountChange` routes to list/review/apply updates.
  - Programs/Media: new Program form load/save helpers, overview and media tabs, map Program info view, media gallery, and dashboard file upload; backend `fileChange` and `instrumentChangePhoto` routes to manage PDFs and instrument photos.
  - DB/Util: new tables `file_change`, `instrument_change_photo`, and performance indexes; added `formatDate` util.

- **Migration**
  - Run new SQL: `server/db/schema/file_change.sql`, `instrument_change_photo.sql`, and `indexes.sql`.
  - Ensure S3 access is configured for new media endpoints.
  - Verify each region has at most one assigned director; remove extra assignments if present.

<sup>Written for commit 4dc652d9c35d97c6bddd25f3055d20ef25ba91fc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

