### PR TITLE
Fix Resolved flow for program updates

### DIFF
--- a/client/src/components/media/Media.jsx
+++ b/client/src/components/media/Media.jsx
@@ -47,6 +47,8 @@ export const Media = () => {
         created_by: userId,
         update_date: updateDate,
         note: description || 'Media files uploaded',
+        show_on_table: false,
+        resolved: false,
       });
 
       const updateId = programUpdateResponse.data.id;

--- a/client/src/components/updates/ProgramUpdatesTable.jsx
+++ b/client/src/components/updates/ProgramUpdatesTable.jsx
@@ -33,7 +33,7 @@ import { SortArrows } from '../tables/SortArrows';
 import { ProgramUpdateForm } from './forms/ProgramUpdateForm';
 
 function getProgramUpdateStatusLabel(row, t) {
-  return row?.showOnTable ? t('common.resolved') : t('common.unresolved');
+  return row?.resolved ? t('common.resolved') : t('common.unresolved');
 }
 
 export function downloadProgramUpdatesAsCsv(data, t) {
@@ -238,7 +238,7 @@ export const ProgramUpdatesTable = ({
                 </Th>
                 {(showStatus || showFlagAndType) && (
                   <Th
-                    onClick={() => handleSort('showOnTable')}
+                    onClick={() => handleSort('resolved')}
                     cursor="pointer"
                     color="gray.500"
                     fontSize="xs"
@@ -247,7 +247,7 @@ export const ProgramUpdatesTable = ({
                   >
                     {t('updates.colStatus')}
                     <SortArrows
-                      columnKey="showOnTable"
+                      columnKey="resolved"
                       sortOrder={sortOrder}
                     />
                   </Th>
@@ -350,7 +350,7 @@ export const ProgramUpdatesTable = ({
                     </Td>
                     {(showStatus || showFlagAndType) && (
                       <Td>
-                        <StatusBadge status={row.showOnTable} />
+                        <StatusBadge status={row.resolved} />
                       </Td>
                     )}
                     <Td>

--- a/client/src/components/updates/config/updatesColumnConfig.js
+++ b/client/src/components/updates/config/updatesColumnConfig.js
@@ -13,7 +13,7 @@ export const programDirectorFilterColumns = [
   {
     key: 'status',
     type: 'select',
-    options: ['Pending', 'Reviewed', 'Approved', 'Resolved'],
+    options: ['Resolved', 'Unresolved'],
   },
   { key: 'note', type: 'text' },
 ];

--- a/client/src/components/updates/forms/ProgramUpdateForm.jsx
+++ b/client/src/components/updates/forms/ProgramUpdateForm.jsx
@@ -142,7 +142,7 @@ export const ProgramUpdateForm = ({
     setIsSaving(true);
     try {
       await backend.put(`/program-updates/${programUpdateId}`, {
-        show_on_table: false,
+        resolved: false,
         note: notes,
         title,
         programId,
@@ -164,7 +164,7 @@ export const ProgramUpdateForm = ({
     setIsSaving(true);
     try {
       await backend.put(`/program-updates/${programUpdateId}`, {
-        show_on_table: true,
+        resolved: true,
         note: notes,
         title,
         programId,
@@ -547,7 +547,7 @@ export const ProgramUpdateForm = ({
     setGraduatedNumber(valueAsNumber);
   };
 
-  const areEditControlsDisabled = Boolean(selectedUpdate?.showOnTable);
+  const areEditControlsDisabled = Boolean(selectedUpdate?.resolved);
 
   const drawerSize = isFullScreen ? 'full' : 'lg';
   return (
@@ -916,7 +916,7 @@ export const ProgramUpdateForm = ({
             w="full"
             p={4}
           >
-            {!selectedUpdate?.showOnTable && (
+            {!selectedUpdate?.resolved && (
               <HStack spacing={3}>
                 <Button
                   variant="outline"

--- a/client/src/components/updates/forms/createForm/CreateUpdateDrawer.jsx
+++ b/client/src/components/updates/forms/createForm/CreateUpdateDrawer.jsx
@@ -630,6 +630,7 @@ export const CreateUpdateDrawer = ({
 
       const response = await backend.post('/program-updates', {
         ...programUpdateData,
+        show_on_table: true,
         resolved: false,
       });
       const newUpdateId = response.data.id;

--- a/client/src/components/updates/forms/createForm/CreateUpdateDrawer.jsx
+++ b/client/src/components/updates/forms/createForm/CreateUpdateDrawer.jsx
@@ -630,7 +630,7 @@ export const CreateUpdateDrawer = ({
 
       const response = await backend.post('/program-updates', {
         ...programUpdateData,
-        show_on_table: false,
+        resolved: false,
       });
       const newUpdateId = response.data.id;
 

--- a/client/src/components/updates/programDirectorView/ProgramDirectorUpdatesTable.jsx
+++ b/client/src/components/updates/programDirectorView/ProgramDirectorUpdatesTable.jsx
@@ -22,7 +22,7 @@ import { FiStar } from 'react-icons/fi';
 import { SortArrows } from '../../tables/SortArrows';
 
 function formatStatus(row, t) {
-  const isResolved = Boolean(row.showOnTable);
+  const isResolved = Boolean(row.resolved);
   return (
     <Badge
       bg={isResolved ? 'gray.100' : 'red.100'}

--- a/client/src/components/updates/programDirectorView/ProgramDirectorView.jsx
+++ b/client/src/components/updates/programDirectorView/ProgramDirectorView.jsx
@@ -33,6 +33,9 @@ import { downloadProgramUpdatesAsCsv } from '../downloadProgramUpdatesAsCsv';
 import { CreateUpdateDrawer } from '../forms/createForm/CreateUpdateDrawer';
 import { ProgramDirectorUpdatesTable } from './ProgramDirectorUpdatesTable';
 
+const getProgramDirectorStatus = (row) =>
+  row?.resolved ? 'Resolved' : 'Unresolved';
+
 export const ProgramDirectorView = ({ data, isLoading, onSave }) => {
   const { t } = useTranslation();
   const [searchQuery, setSearchQuery] = useState('');
@@ -61,11 +64,16 @@ export const ProgramDirectorView = ({ data, isLoading, onSave }) => {
 
   const sortedData = useMemo(() => {
     if (!data) return [];
-    return [...data].sort((a, b) => {
-      const dateA = new Date(a.updatedAt || a.updateDate || 0).getTime();
-      const dateB = new Date(b.updatedAt || b.updateDate || 0).getTime();
-      return dateB - dateA;
-    });
+    return [...data]
+      .map((row) => ({
+        ...row,
+        status: getProgramDirectorStatus(row),
+      }))
+      .sort((a, b) => {
+        const dateA = new Date(a.updatedAt || a.updateDate || 0).getTime();
+        const dateB = new Date(b.updatedAt || b.updateDate || 0).getTime();
+        return dateB - dateA;
+      });
   }, [data]);
 
   const filteredData = useMemo(

--- a/server/db/schema/program_update.sql
+++ b/server/db/schema/program_update.sql
@@ -7,5 +7,6 @@ CREATE TABLE program_update (
   note           TEXT,
   show_on_table  BOOLEAN NOT NULL DEFAULT TRUE
   updated_at timestamp with time zone NOT NULL DEFAULT now(),
-  created_at timestamp with time zone NOT NULL DEFAULT now()
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  resolved boolean NOT NULL DEFAULT false
 );

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -26,14 +26,14 @@ adminRouter.get('/programs', async (req, res) => {
         SELECT pu.program_id, SUM(ec.enrollment_change) - SUM(ec.graduated_change) AS total_enrollment
         FROM enrollment_change ec
         JOIN program_update pu ON pu.id = ec.update_id
-        WHERE pu.show_on_table = TRUE
+        WHERE pu.resolved = TRUE OR pu.show_on_table IS FALSE
         GROUP BY pu.program_id
       ) ec ON ec.program_id = p.id
       LEFT JOIN (
         SELECT u.program_id, SUM(ic.amount_changed) AS total_instruments
         FROM instrument_change ic
         JOIN program_update u ON u.id = ic.update_id
-        WHERE u.show_on_table = TRUE
+        WHERE u.resolved = TRUE OR u.show_on_table IS FALSE
         GROUP BY u.program_id
       ) ic ON ic.program_id = p.id;`
     );
@@ -53,11 +53,11 @@ adminRouter.get('/stats', async (req, res) => {
         (SELECT COALESCE(SUM(ec.enrollment_change), 0) - COALESCE(SUM(ec.graduated_change), 0)
          FROM enrollment_change ec
          JOIN program_update pu ON pu.id = ec.update_id
-         WHERE pu.show_on_table = TRUE) AS total_students,
+         WHERE pu.resolved = TRUE OR pu.show_on_table IS FALSE) AS total_students,
         (SELECT COALESCE(SUM(ic.amount_changed), 0) 
          FROM instrument_change ic
          JOIN program_update pu ON pu.id = ic.update_id
-         WHERE pu.show_on_table = TRUE) AS total_instruments`
+         WHERE pu.resolved = TRUE OR pu.show_on_table IS FALSE) AS total_instruments`
     );
     res.json(keysToCamel(stats[0]));
   } catch (err) {

--- a/server/routes/programDirector.js
+++ b/server/routes/programDirector.js
@@ -39,9 +39,9 @@ directorRouter.get('/me/:userId/stats', async (req, res) => {
     const stats = await db.query(
       `SELECT
           (SELECT COALESCE(SUM(ec.enrollment_change), 0) - COALESCE(SUM(ec.graduated_change), 0) FROM enrollment_change ec
-           JOIN program_update pu ON pu.id = ec.update_id WHERE pu.program_id = $1 AND pu.show_on_table = TRUE) AS students,
+           JOIN program_update pu ON pu.id = ec.update_id WHERE pu.program_id = $1 AND (pu.resolved = TRUE OR pu.show_on_table IS FALSE)) AS students,
           (SELECT COALESCE(SUM(ic.amount_changed), 0) FROM instrument_change ic
-           JOIN program_update pu ON pu.id = ic.update_id WHERE pu.program_id = $1 AND pu.show_on_table = TRUE) AS instruments`,
+           JOIN program_update pu ON pu.id = ic.update_id WHERE pu.program_id = $1 AND (pu.resolved = TRUE OR pu.show_on_table IS FALSE)) AS instruments`,
       [programId]
     );
     const row = stats[0];

--- a/server/routes/programUpdate.js
+++ b/server/routes/programUpdate.js
@@ -69,14 +69,22 @@ programUpdateRouter.get('/:id/date', async (req, res) => {
 
 // Creating a program update
 programUpdateRouter.post('/', async (req, res) => {
-  const { title, program_id, created_by, update_date, note, show_on_table } =
+  const {
+    title,
+    program_id,
+    created_by,
+    update_date,
+    note,
+    show_on_table,
+    resolved,
+  } =
     req.body;
   try {
     const newEntry = await db.query(
-      `INSERT INTO program_update (title, program_id, created_by, update_date, note, show_on_table, updated_at)
-            VALUES ($1, $2, $3, $4, $5, COALESCE($6, TRUE), CURRENT_TIMESTAMP)
+      `INSERT INTO program_update (title, program_id, created_by, update_date, note, show_on_table, resolved, updated_at)
+            VALUES ($1, $2, $3, $4, $5, COALESCE($6, TRUE), COALESCE($7, FALSE), CURRENT_TIMESTAMP)
             RETURNING *`,
-      [title, program_id, created_by, update_date, note, show_on_table]
+      [title, program_id, created_by, update_date, note, show_on_table, resolved]
     );
     res.status(201).json(keysToCamel(newEntry[0]));
   } catch (err) {
@@ -89,8 +97,15 @@ programUpdateRouter.post('/', async (req, res) => {
 programUpdateRouter.put('/:id', async (req, res) => {
   try {
     const { id } = req.params;
-    const { title, program_id, created_by, update_date, note, show_on_table } =
-      req.body;
+    const {
+      title,
+      program_id,
+      created_by,
+      update_date,
+      note,
+      show_on_table,
+      resolved,
+    } = req.body;
 
     const newProgramUpdate = await db.query(
       `UPDATE program_update SET
@@ -100,10 +115,20 @@ programUpdateRouter.put('/:id', async (req, res) => {
             update_date = COALESCE($4, update_date),
             note = COALESCE($5, note),
             show_on_table = COALESCE($6, show_on_table),
+            resolved = COALESCE($7, resolved),
             updated_at = CURRENT_TIMESTAMP
-            WHERE id = $7
+            WHERE id = $8
             RETURNING *`,
-      [title, program_id, created_by, update_date, note, show_on_table, id]
+      [
+        title,
+        program_id,
+        created_by,
+        update_date,
+        note,
+        show_on_table,
+        resolved,
+        id,
+      ]
     );
 
     if (newProgramUpdate.length === 0) {

--- a/server/routes/regionalDirector.js
+++ b/server/routes/regionalDirector.js
@@ -73,14 +73,14 @@ regionalDirectorRouter.get('/me/:id/stats', async (req, res) => {
            JOIN program_update pu ON pu.id = ec.update_id
            JOIN program p ON p.id = pu.program_id
            JOIN country c ON c.id = p.country
-           WHERE c.region_id = $1 AND pu.show_on_table = TRUE) AS total_students,
+           WHERE c.region_id = $1 AND (pu.resolved = TRUE OR pu.show_on_table IS FALSE)) AS total_students,
           
           (SELECT COALESCE(SUM(ic.amount_changed), 0) 
            FROM instrument_change ic
            JOIN program_update pu ON pu.id = ic.update_id
            JOIN program p ON p.id = pu.program_id
            JOIN country c ON c.id = p.country
-           WHERE c.region_id = $1 AND pu.show_on_table = TRUE) AS total_instruments`,
+           WHERE c.region_id = $1 AND (pu.resolved = TRUE OR pu.show_on_table IS FALSE)) AS total_instruments`,
       [regionId]
     );
     res.status(200).json(keysToCamel(stats[0]));

--- a/server/routes/updatesPermissions.js
+++ b/server/routes/updatesPermissions.js
@@ -36,6 +36,7 @@ updatesPermissionsRouter.get('/media-updates/:id', async (req, res) => {
           program_update.update_date,
           program_update.note,
           program_update.show_on_table,
+          program_update.resolved,
           program_update.updated_at,
           program.name AS program_name,
           creator.first_name,
@@ -68,12 +69,13 @@ updatesPermissionsRouter.get('/program-updates/pd/:id', async (req, res) => {
           program_update.updated_at,
           program_update.note,
           program_update.show_on_table,
+          program_update.resolved,
           program.name,
           creator.first_name,
           creator.last_name,
           creator.role,
           creator.picture,
-          program.status,
+          program.status AS program_status,
           EXISTS (
             SELECT 1 FROM instrument_change ic
             WHERE ic.update_id = program_update.id
@@ -120,6 +122,7 @@ updatesPermissionsRouter.get('/program-updates/pd/:id', async (req, res) => {
       INNER JOIN program ON program_update.program_id = program.id
       LEFT JOIN gcf_user AS creator ON creator.id = program_update.created_by
       INNER JOIN program_director ON program_director.program_id = program.id AND program_director.user_id = $1
+      WHERE program_update.show_on_table = TRUE
       ORDER BY program_update.update_date DESC;`;
 
     const data = await db.query(finalQuery, [id]);
@@ -159,12 +162,13 @@ updatesPermissionsRouter.get('/program-updates/:id', async (req, res) => {
           program_update.updated_at,
           program_update.note,
           program_update.show_on_table,
+          program_update.resolved,
           program.name,
           creator.first_name,
           creator.last_name,
           creator.role,
           creator.picture,
-          program.status,
+          program.status AS program_status,
           EXISTS (
             SELECT 1 FROM instrument_change ic
             WHERE ic.update_id = program_update.id
@@ -178,6 +182,7 @@ updatesPermissionsRouter.get('/program-updates/:id', async (req, res) => {
       INNER JOIN program ON program_update.program_id = program.id
       LEFT JOIN gcf_user AS creator ON creator.id = program_update.created_by
       ${filterJoin}
+      WHERE program_update.show_on_table = TRUE
       ORDER BY program_update.update_date DESC;`;
 
     const data = await db.query(finalQuery, filterJoin ? [id] : []);


### PR DESCRIPTION
Adds a new column to program updates for resolved. 
Show_on_table affects what is displayed for admin/rd

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “Resolved” flow for program updates by adding a dedicated `resolved` field and using it for status, sorting, and filters. `show_on_table` is now PD visibility only, with explicit defaults, and Admin/RD stats use the resolved state or hidden updates.

- **Bug Fixes**
  - Added `resolved` boolean to `program_update`; client now reads/writes `resolved` instead of `show_on_table` for status.
  - New updates create with `resolved: false` and `show_on_table: true` (media uploads: `show_on_table: false`); resolving sets `resolved: true`; edit controls disable when resolved.
  - Tables: sort and badges use `resolved`; PD filter options simplified to “Resolved/Unresolved”.
  - Admin/Regional Director stats include updates where `resolved = TRUE` or `show_on_table = FALSE`.
  - PD-facing lists and server endpoints only include updates with `show_on_table = TRUE`.

- **Migration**
  - Run the DB migration to add `program_update.resolved BOOLEAN NOT NULL DEFAULT FALSE`. Deploy server and client together.

<sup>Written for commit eb2c8e824559451e9fcc08f2a95fdc62cd5c977d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

