### PR TITLE
Hover Rows Admin Dashboard, Hover Program Cards Map

### DIFF
--- a/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
+++ b/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
@@ -12,6 +12,8 @@ import {
   VStack,
 } from '@chakra-ui/react';
 
+import { FiEdit2 } from 'react-icons/fi';
+
 import 'flag-icons/css/flag-icons.min.css';
 
 import ISO6391 from 'iso-639-1';
@@ -34,17 +36,23 @@ export function ExpandableProgramRow({ p, onEdit }) {
         .join(', ')
     : '';
   const flagCode = isoCodeToFlagIconCode(p.isoCode);
+
   return (
     <>
       <Tr
         onClick={onToggle}
         cursor="pointer"
+        _hover={{
+          bg: 'gray.100',
+          '& .action-group': { opacity: 1, visibility: 'visible' },
+        }}
         sx={{
           '& td': {
             borderBottom: isOpen ? 'none' : '1px solid',
             borderColor: 'gray.200',
           },
         }}
+        transition="background 0.2s"
       >
         <Td>{p.title}</Td>
         <Td>
@@ -88,17 +96,49 @@ export function ExpandableProgramRow({ p, onEdit }) {
               : null}
           </VStack>
         </Td>
-        <Td>{p.totalInstruments}</Td>
+        <Td>
+          <HStack
+            justify="space-between"
+            minW="100px"
+          >
+            <Text>{p.totalInstruments}</Text>
+
+            <Box
+              className="action-group"
+              opacity={0}
+              visibility="hidden"
+              transition="all 0.2s"
+            >
+              <Button
+                size="sm"
+                variant="outline"
+                leftIcon={<FiEdit2 />}
+                colorScheme="teal"
+                bg="white"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEdit?.(p);
+                }}
+              >
+                {t('common.edit')}
+              </Button>
+            </Box>
+          </HStack>
+        </Td>
       </Tr>
-      <Tr role="group">
+
+      <Tr>
         <Td
-          colSpan={6}
+          colSpan={7}
           borderBottom={isOpen ? '1px solid' : 'none'}
           borderColor="gray.200"
           p={isOpen ? undefined : 0}
         >
           <Collapse in={isOpen}>
-            <HStack align="start">
+            <HStack
+              align="start"
+              py={4}
+            >
               <Box
                 flex="1"
                 display="grid"
@@ -217,40 +257,6 @@ export function ExpandableProgramRow({ p, onEdit }) {
                 </Box>
               </Box>
             </HStack>
-          </Collapse>
-        </Td>
-        <Td
-          colSpan={1}
-          borderBottom={isOpen ? '1px solid' : 'none'}
-          borderColor="gray.200"
-          p={isOpen ? undefined : 0}
-          position="sticky"
-          right={0}
-        >
-          <Collapse in={isOpen}>
-            <Box
-              display="flex"
-              alignItems="flex-end"
-              justifyContent="flex-end"
-              h="100%"
-              pb={2}
-            >
-              <Button
-                size="xs"
-                border="1px solid"
-                bg="white"
-                opacity={0}
-                _groupHover={{ opacity: 1 }}
-                transition="opacity 0.15s"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onEdit?.(p);
-                }}
-                leftIcon={<EditIcon />}
-              >
-                {t('expandableProgramRow.update')}
-              </Button>
-            </Box>
           </Collapse>
         </Td>
       </Tr>

--- a/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
+++ b/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
@@ -105,8 +105,8 @@ export function ExpandableProgramRow({ p, onEdit }) {
 
             <Box
               className="action-group"
-              opacity={0}
-              visibility="hidden"
+              opacity={{ base: 1, md: 0 }}
+              visibility={{ base: 'visible', md: 'hidden' }}
               transition="all 0.2s"
             >
               <Button

--- a/client/src/components/map/Map.jsx
+++ b/client/src/components/map/Map.jsx
@@ -421,7 +421,11 @@ export const Map = () => {
                     cursor="pointer"
                     onClick={() => setSelectedProgram(program)}
                     transition="transform 0.2s"
-                    _hover={{ transform: 'scale(1.03)' }}
+                    border="2px solid transparent"
+                    borderRadius="md"
+                    _hover={{
+                      borderColor: 'teal.500',
+                    }}
                   >
                     <CardView
                       programId={program.id}


### PR DESCRIPTION
## Description
<img width="1431" height="123" alt="image" src="https://github.com/user-attachments/assets/7c9abd1d-534b-41ff-857d-becb031aae9c" />
<img width="1445" height="114" alt="image" src="https://github.com/user-attachments/assets/76619c18-5d62-4e19-aaa2-db1df05c4529" />
- Previously, users had to click individual rows to reveal an "Update" button for each program
- Now, users can hover on each row to reveal an "Edit" button

<img width="1078" height="319" alt="image" src="https://github.com/user-attachments/assets/c2cac93f-7e8d-410d-96a5-e56e2fee1414" />
- Added a blue border while hovering over cards on the map
- Removed the zoom animation when hovering over cards

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved program editing and hover cues. Admin rows now highlight and show an Edit button (always visible on mobile), and map program cards show a teal border instead of zoom.

- **New Features**
  - Admin dashboard: Hovering a program row highlights it and reveals an Edit button; clicking the row still expands details. On mobile, the Edit button is always visible.
  - Map: Hovering a program card shows a teal border; removed the zoom animation to reduce motion.

<sup>Written for commit 53ac22f99d00e0e63ad1e68776f2125fc41acac7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

