### PR TITLE
Create Partner Org tab

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -171,6 +171,7 @@
     "updates": "Updates",
     "accounts": "Accounts",
     "regions": "Regions",
+    "partners": "Partners",
     "media": "Media",
     "logoAlt": "Logo"
   },
@@ -298,7 +299,8 @@
   "emptyState": {
     "noAccounts": "No accounts have been created yet. Click 'New Account' to get started.",
     "noPrograms": "No programs have been created yet. Click 'New Program' to get started.",
-    "noUpdates": "No updates have been made yet."
+    "noUpdates": "No updates have been made yet.",
+    "noPartners": "No partner organizations have been added yet. Click '+ New Partner' to get started."
   },
   "programForm": {
     "drawerTitle": "Program",
@@ -638,5 +640,25 @@
   "fullscreenFlyout": {
     "minimize": "Minimize",
     "expand": "Expand"
+  },
+  "partners": {
+    "pageTitle": "Partner Organizations",
+    "newPartner": "+ New Partner",
+    "editPartner": "Edit Partner Organization",
+    "newPartnerTitle": "New Partner Organization",
+    "partnerName": "Organization Name",
+    "partnerNamePlaceholder": "Enter organization name",
+    "partnerNameRequired": "Organization name is required.",
+    "deletePartnerTitle": "Delete Partner Organization",
+    "deletePartnerBody": "Are you sure you want to delete this partner organization?",
+    "toastSaved": "Partner organization saved successfully",
+    "toastErrorSave": "Error saving partner organization",
+    "toastDeleted": "Partner organization deleted successfully",
+    "toastErrorDelete": "Error deleting partner organization",
+    "searchPlaceholder": "Search partner organizations...",
+    "columnName": "Organization Name",
+    "fieldLabel": "Partner Organization",
+    "fieldPlaceholder": "Enter partner organization",
+    "fieldSelected": "Selected: {{name}}"
   }
 }

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -171,6 +171,7 @@
     "updates": "Actualizaciones",
     "accounts": "Cuentas",
     "regions": "Regiones",
+    "partners": "Socios",
     "media": "Medios de comunicación",
     "logoAlt": "Logo"
   },
@@ -298,7 +299,8 @@
   "emptyState": {
     "noAccounts": "Aún no se han creado cuentas. Haga clic en 'Nueva cuenta' para comenzar.",
     "noPrograms": "Aún no se han creado programas. Haga clic en 'Nuevo programa' para comenzar.",
-    "noUpdates": "Aún no se han realizado actualizaciones."
+    "noUpdates": "Aún no se han realizado actualizaciones.",
+    "noPartners": "Aún no se han agregado organizaciones asociadas. Haga clic en '+ Nuevo socio' para comenzar."
   },
   "programForm": {
     "drawerTitle": "Programa",
@@ -635,5 +637,25 @@
   "fullscreenFlyout": {
     "minimize": "Minimizar",
     "expand": "Expandir"
+  },
+  "partners": {
+    "pageTitle": "Organizaciones Asociadas",
+    "newPartner": "+ Nuevo Socio",
+    "editPartner": "Editar Organización Asociada",
+    "newPartnerTitle": "Nueva Organización Asociada",
+    "partnerName": "Nombre de la Organización",
+    "partnerNamePlaceholder": "Ingrese el nombre de la organización",
+    "partnerNameRequired": "El nombre de la organización es obligatorio.",
+    "deletePartnerTitle": "Eliminar Organización Asociada",
+    "deletePartnerBody": "¿Está seguro de que desea eliminar esta organización asociada?",
+    "toastSaved": "Organización asociada guardada exitosamente",
+    "toastErrorSave": "Error al guardar la organización asociada",
+    "toastDeleted": "Organización asociada eliminada exitosamente",
+    "toastErrorDelete": "Error al eliminar la organización asociada",
+    "searchPlaceholder": "Buscar organizaciones asociadas...",
+    "columnName": "Nombre de la Organización",
+    "fieldLabel": "Organización Asociada",
+    "fieldPlaceholder": "Ingrese la organización asociada",
+    "fieldSelected": "Seleccionado: {{name}}"
   }
 }

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -171,6 +171,7 @@
     "updates": "Mises à jour",
     "accounts": "Comptes",
     "regions": "Régions",
+    "partners": "Partenaires",
     "media": "Médias",
     "logoAlt": "Logo"
   },
@@ -298,7 +299,8 @@
   "emptyState": {
     "noAccounts": "Aucun compte n'a encore été créé. Cliquez sur « Nouveau compte » pour commencer.",
     "noPrograms": "Aucun programme n'a encore été créé. Cliquez sur « Nouveau programme » pour commencer.",
-    "noUpdates": "Aucune mise à jour n'a encore été effectuée."
+    "noUpdates": "Aucune mise à jour n'a encore été effectuée.",
+    "noPartners": "Aucune organisation partenaire n'a encore été ajoutée. Cliquez sur '+ Nouveau partenaire' pour commencer."
   },
   "programForm": {
     "drawerTitle": "Programme",
@@ -635,5 +637,25 @@
   "fullscreenFlyout": {
     "minimize": "Minimiser",
     "expand": "Développer"
+  },
+  "partners": {
+    "pageTitle": "Organisations Partenaires",
+    "newPartner": "+ Nouveau Partenaire",
+    "editPartner": "Modifier l'Organisation Partenaire",
+    "newPartnerTitle": "Nouvelle Organisation Partenaire",
+    "partnerName": "Nom de l'Organisation",
+    "partnerNamePlaceholder": "Entrez le nom de l'organisation",
+    "partnerNameRequired": "Le nom de l'organisation est obligatoire.",
+    "deletePartnerTitle": "Supprimer l'Organisation Partenaire",
+    "deletePartnerBody": "Êtes-vous sûr de vouloir supprimer cette organisation partenaire ?",
+    "toastSaved": "Organisation partenaire enregistrée avec succès",
+    "toastErrorSave": "Erreur lors de l'enregistrement de l'organisation partenaire",
+    "toastDeleted": "Organisation partenaire supprimée avec succès",
+    "toastErrorDelete": "Erreur lors de la suppression de l'organisation partenaire",
+    "searchPlaceholder": "Rechercher des organisations partenaires...",
+    "columnName": "Nom de l'Organisation",
+    "fieldLabel": "Organisation Partenaire",
+    "fieldPlaceholder": "Entrez l'organisation partenaire",
+    "fieldSelected": "Sélectionné : {{name}}"
   }
 }

--- a/client/public/locales/zh/translation.json
+++ b/client/public/locales/zh/translation.json
@@ -171,6 +171,7 @@
     "updates": "更新",
     "accounts": "账户",
     "regions": "地区",
+    "partners": "合作伙伴",
     "media": "媒体",
     "logoAlt": "标识"
   },
@@ -298,7 +299,8 @@
   "emptyState": {
     "noAccounts": "尚未创建任何帐户。单击“新帐户”即可开始。",
     "noPrograms": "尚未创建任何程序。单击“新程序”即可开始。",
-    "noUpdates": "尚未进行任何更新。"
+    "noUpdates": "尚未进行任何更新。",
+    "noPartners": "尚未添加任何合作伙伴组织。点击"+ 新建合作伙伴"开始。"
   },
   "programForm": {
     "drawerTitle": "程序",
@@ -635,5 +637,25 @@
   "fullscreenFlyout": {
     "minimize": "最小化",
     "expand": "扩张"
+  },
+  "partners": {
+    "pageTitle": "合作伙伴组织",
+    "newPartner": "+ 新建合作伙伴",
+    "editPartner": "编辑合作伙伴组织",
+    "newPartnerTitle": "新建合作伙伴组织",
+    "partnerName": "组织名称",
+    "partnerNamePlaceholder": "输入组织名称",
+    "partnerNameRequired": "组织名称为必填项。",
+    "deletePartnerTitle": "删除合作伙伴组织",
+    "deletePartnerBody": "您确定要删除此合作伙伴组织吗？",
+    "toastSaved": "合作伙伴组织已成功保存",
+    "toastErrorSave": "保存合作伙伴组织时出错",
+    "toastDeleted": "合作伙伴组织已成功删除",
+    "toastErrorDelete": "删除合作伙伴组织时出错",
+    "searchPlaceholder": "搜索合作伙伴组织...",
+    "columnName": "组织名称",
+    "fieldLabel": "合作伙伴组织",
+    "fieldPlaceholder": "输入合作伙伴组织",
+    "fieldSelected": "已选择：{{name}}"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -20,6 +20,7 @@ import {
 import { Account } from './components/accounts/Account';
 import { Map } from './components/map/Map';
 import { Media } from './components/media/Media';
+import { PartnersPage } from './components/partners/PartnersPage';
 import { RegionsPage } from './components/regions/RegionsPage';
 
 const App = () => {
@@ -103,6 +104,16 @@ const App = () => {
                   <Route
                     path={'regions'}
                     element={<RegionsPage />}
+                  />
+
+                  <Route
+                    path={'partners'}
+                    element={
+                      <ProtectedRoute
+                        element={<PartnersPage />}
+                        allowedRoles={['Super Admin', 'Admin']}
+                      />
+                    }
                   />
                 </Route>
 

--- a/client/src/components/badges/EmptyStateBadge.jsx
+++ b/client/src/components/badges/EmptyStateBadge.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { FiBell, FiUsers } from 'react-icons/fi';
 import { HiOutlineMusicalNote } from 'react-icons/hi2';
 import { IoHomeOutline } from 'react-icons/io5';
+import { MdOutlineHandshake } from 'react-icons/md';
 
 const BADGE_CONFIG = {
   'no-accounts': {
@@ -17,6 +18,10 @@ const BADGE_CONFIG = {
   'no-updates': {
     icon: FiBell,
     messageKey: 'emptyState.noUpdates',
+  },
+  'no-partners': {
+    icon: MdOutlineHandshake,
+    messageKey: 'emptyState.noPartners',
   },
 };
 

--- a/client/src/components/navigation/Sidebar.jsx
+++ b/client/src/components/navigation/Sidebar.jsx
@@ -8,6 +8,7 @@ import { BsMap } from 'react-icons/bs';
 import { FaGuitar } from 'react-icons/fa';
 import { HiOutlineUser } from 'react-icons/hi';
 import {
+  MdOutlineHandshake,
   MdOutlineHome,
   MdOutlineNotifications,
   MdPermMedia,
@@ -90,6 +91,16 @@ export const Sidebar = () => {
           />
         ),
         path: '/regions',
+      },
+      {
+        name: t('sidebar.partners'),
+        icon: (
+          <Icon
+            as={MdOutlineHandshake}
+            boxSize="20px"
+          />
+        ),
+        path: '/partners',
       },
     ];
   } else if (role === 'Regional Director') {

--- a/client/src/components/partners/PartnerForm.jsx
+++ b/client/src/components/partners/PartnerForm.jsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogBody,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+
+import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { useTranslation } from 'react-i18next';
+
+const PartnerForm = ({ isOpen, partner, onClose, onSave, onDelete }) => {
+  const { t } = useTranslation();
+  const { backend } = useBackendContext();
+  const [name, setName] = useState('');
+  const [nameError, setNameError] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false);
+  const cancelRef = useRef();
+  const toast = useToast();
+
+  useEffect(() => {
+    setName(partner?.name ?? '');
+    setNameError(false);
+  }, [partner, isOpen]);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setNameError(true);
+      return;
+    }
+    setNameError(false);
+    try {
+      if (partner) {
+        await backend.put(`/partners/${partner.id}`, { name: name.trim() });
+      } else {
+        await backend.post('/partners', { name: name.trim() });
+      }
+      toast({
+        title: t('partners.toastSaved'),
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      });
+      onSave();
+    } catch (err) {
+      console.error('Error saving partner:', err);
+      toast({
+        title: t('partners.toastErrorSave'),
+        description: err.response?.data?.message || err.message,
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await backend.delete(`/partners/${partner.id}`);
+      toast({
+        title: t('partners.toastDeleted'),
+        status: 'success',
+        duration: 5000,
+        isClosable: true,
+      });
+      setIsDeleteDialogOpen(false);
+      onDelete();
+    } catch (err) {
+      console.error('Error deleting partner:', err);
+      toast({
+        title: t('partners.toastErrorDelete'),
+        description: err.response?.data?.message || err.message,
+        status: 'error',
+        duration: 5000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      placement="right"
+      onClose={onClose}
+      size="md"
+    >
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerCloseButton />
+        <DrawerHeader>
+          {partner ? t('partners.editPartner') : t('partners.newPartnerTitle')}
+        </DrawerHeader>
+        <DrawerBody>
+          <VStack spacing={4}>
+            <FormControl
+              isRequired
+              isInvalid={nameError}
+            >
+              <FormLabel>{t('partners.partnerName')}</FormLabel>
+              <Input
+                value={name}
+                placeholder={t('partners.partnerNamePlaceholder')}
+                onChange={(e) => {
+                  setName(e.target.value);
+                  setNameError(false);
+                }}
+              />
+              {nameError && (
+                <FormErrorMessage>
+                  {t('partners.partnerNameRequired')}
+                </FormErrorMessage>
+              )}
+            </FormControl>
+
+            <Flex
+              width="100%"
+              justifyContent="space-between"
+              mt={4}
+            >
+              {partner && (
+                <Button
+                  colorScheme="red"
+                  variant="ghost"
+                  onClick={() => setIsDeleteDialogOpen(true)}
+                >
+                  {t('common.delete')}
+                </Button>
+              )}
+              <Flex
+                gap={2}
+                ml="auto"
+              >
+                <Button
+                  variant="outline"
+                  onClick={() => setIsCancelDialogOpen(true)}
+                >
+                  {t('common.cancel')}
+                </Button>
+                <Button
+                  colorScheme="teal"
+                  isDisabled={!name.trim()}
+                  onClick={handleSave}
+                >
+                  {t('common.save')}
+                </Button>
+              </Flex>
+            </Flex>
+          </VStack>
+
+          <AlertDialog
+            isOpen={isDeleteDialogOpen}
+            leastDestructiveRef={cancelRef}
+            onClose={() => setIsDeleteDialogOpen(false)}
+          >
+            <AlertDialogOverlay>
+              <AlertDialogContent>
+                <AlertDialogHeader
+                  fontSize="lg"
+                  fontWeight="bold"
+                >
+                  {t('partners.deletePartnerTitle')}
+                </AlertDialogHeader>
+                <AlertDialogBody>
+                  {t('partners.deletePartnerBody')}
+                </AlertDialogBody>
+                <AlertDialogFooter>
+                  <Button
+                    ref={cancelRef}
+                    onClick={() => setIsDeleteDialogOpen(false)}
+                  >
+                    {t('common.cancel')}
+                  </Button>
+                  <Button
+                    colorScheme="red"
+                    onClick={handleDelete}
+                    ml={3}
+                  >
+                    {t('common.delete')}
+                  </Button>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialogOverlay>
+          </AlertDialog>
+
+          <AlertDialog
+            isOpen={isCancelDialogOpen}
+            leastDestructiveRef={cancelRef}
+            onClose={() => setIsCancelDialogOpen(false)}
+          >
+            <AlertDialogOverlay>
+              <AlertDialogContent>
+                <AlertDialogHeader
+                  fontSize="lg"
+                  fontWeight="bold"
+                >
+                  {t('regions.unsavedTitle')}
+                </AlertDialogHeader>
+                <AlertDialogBody>{t('regions.unsavedBody')}</AlertDialogBody>
+                <AlertDialogFooter>
+                  <Button
+                    isDisabled={!name.trim()}
+                    onClick={async () => {
+                      await handleSave();
+                      setIsCancelDialogOpen(false);
+                    }}
+                  >
+                    {t('regions.saveExit')}
+                  </Button>
+                  <Button
+                    colorScheme="red"
+                    onClick={() => {
+                      onClose();
+                      setIsCancelDialogOpen(false);
+                    }}
+                    ml={3}
+                  >
+                    {t('common.exitWithoutSaving')}
+                  </Button>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialogOverlay>
+          </AlertDialog>
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default PartnerForm;

--- a/client/src/components/partners/PartnerOrganizationField.jsx
+++ b/client/src/components/partners/PartnerOrganizationField.jsx
@@ -4,13 +4,12 @@ import { Box, FormControl, FormLabel, Text } from '@chakra-ui/react';
 
 import { SearchInput } from '@/components/common/SearchInput';
 import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { useTranslation } from 'react-i18next';
 
-export function PartnerOrganizationField({
-  valueId,
-  onChangeId,
-  label = 'Partner Organization',
-}) {
+export function PartnerOrganizationField({ valueId, onChangeId, label }) {
+  const { t } = useTranslation();
   const { backend } = useBackendContext();
+  const resolvedLabel = label ?? t('partners.fieldLabel');
   const [partnerOrgs, setPartnerOrgs] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -71,7 +70,7 @@ export function PartnerOrganizationField({
         fontWeight="normal"
         color="gray"
       >
-        {label}
+        {resolvedLabel}
       </FormLabel>
       <Box>
         <SearchInput
@@ -86,7 +85,7 @@ export function PartnerOrganizationField({
             handleCreateNew(name);
             setSearchQuery('');
           }}
-          placeholder="Enter Partner Organization"
+          placeholder={t('partners.fieldPlaceholder')}
         />
         {selected && (
           <Text
@@ -94,7 +93,7 @@ export function PartnerOrganizationField({
             color="gray.600"
             mt={1}
           >
-            Selected: {selected.name}
+            {t('partners.fieldSelected', { name: selected.name })}
           </Text>
         )}
       </Box>

--- a/client/src/components/partners/PartnersPage.jsx
+++ b/client/src/components/partners/PartnersPage.jsx
@@ -1,0 +1,95 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { Box, Button, Flex, Text } from '@chakra-ui/react';
+
+import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { useTranslation } from 'react-i18next';
+
+import PartnerForm from './PartnerForm';
+import { PartnersTable } from './PartnersTable';
+
+export const PartnersPage = () => {
+  const { t } = useTranslation();
+  const { backend } = useBackendContext();
+  const [partners, setPartners] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [selectedPartner, setSelectedPartner] = useState(null);
+
+  const fetchPartners = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const res = await backend.get('/partners');
+      setPartners(Array.isArray(res.data) ? res.data : []);
+    } catch (err) {
+      console.error('Error fetching partners:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [backend]);
+
+  useEffect(() => {
+    fetchPartners();
+  }, [fetchPartners]);
+
+  const handleEdit = (partner) => {
+    setSelectedPartner(partner);
+    setIsDrawerOpen(true);
+  };
+
+  const handleNew = () => {
+    setSelectedPartner(null);
+    setIsDrawerOpen(true);
+  };
+
+  const handleRefresh = () => {
+    fetchPartners();
+    setIsDrawerOpen(false);
+  };
+
+  return (
+    <Box>
+      <Flex
+        align="center"
+        justify="space-between"
+        mb={4}
+        mt={4}
+      >
+        <Text
+          fontSize="2xl"
+          fontWeight="semibold"
+        >
+          {t('partners.pageTitle')}
+        </Text>
+        <Button
+          size="sm"
+          color="white"
+          bg="teal.500"
+          _hover={{
+            color: 'teal.500',
+            bg: 'white',
+            border: '2px solid',
+            borderColor: 'teal.500',
+          }}
+          onClick={handleNew}
+        >
+          {t('partners.newPartner')}
+        </Button>
+      </Flex>
+
+      <PartnersTable
+        partners={partners}
+        isLoading={isLoading}
+        onEdit={handleEdit}
+      />
+
+      <PartnerForm
+        isOpen={isDrawerOpen}
+        partner={selectedPartner}
+        onClose={() => setIsDrawerOpen(false)}
+        onSave={handleRefresh}
+        onDelete={handleRefresh}
+      />
+    </Box>
+  );
+};

--- a/client/src/components/partners/PartnersTable.jsx
+++ b/client/src/components/partners/PartnersTable.jsx
@@ -1,0 +1,161 @@
+import { useEffect, useState } from 'react';
+
+import { SearchIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Button,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Spinner,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useColorModeValue,
+} from '@chakra-ui/react';
+
+import { EmptyStateBadge } from '@/components/badges/EmptyStateBadge';
+import { useTableSort } from '@/contexts/hooks/TableSort';
+import { useTranslation } from 'react-i18next';
+import { FiEdit2 } from 'react-icons/fi';
+
+import { SortArrows } from '../tables/SortArrows';
+
+export const PartnersTable = ({ partners, isLoading, onEdit }) => {
+  const { t } = useTranslation();
+  const hoverBg = useColorModeValue('gray.50', 'gray.700');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortedData, setSortedData] = useState(null);
+
+  const filtered = partners.filter((p) =>
+    p.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  useEffect(() => {
+    setSortedData(null);
+  }, [searchQuery]);
+
+  const { sortOrder, handleSort } = useTableSort(filtered, setSortedData);
+  const tableData = sortedData ?? filtered;
+
+  if (isLoading) {
+    return (
+      <Box
+        display="flex"
+        justifyContent="center"
+        py={10}
+      >
+        <Spinner
+          size="xl"
+          color="gray.500"
+        />
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <InputGroup
+        mb={4}
+        maxW="320px"
+      >
+        <InputLeftElement pointerEvents="none">
+          <SearchIcon color="gray.400" />
+        </InputLeftElement>
+        <Input
+          placeholder={t('partners.searchPlaceholder')}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+        />
+      </InputGroup>
+
+      {tableData.length === 0 ? (
+        <EmptyStateBadge variant="no-partners" />
+      ) : (
+        <Box
+          bg="white"
+          borderRadius="xl"
+          overflow="hidden"
+          minW={0}
+          maxW="100%"
+        >
+          <TableContainer maxW="100%">
+            <Table
+              variant="simple"
+              size="md"
+            >
+              <Thead>
+                <Tr>
+                  <Th
+                    onClick={() => handleSort('name')}
+                    cursor="pointer"
+                    color="gray.500"
+                    fontSize="xs"
+                    textTransform="uppercase"
+                    fontWeight="semibold"
+                    letterSpacing="wider"
+                  >
+                    <Text as="span">{t('partners.columnName')}</Text>
+                    <SortArrows
+                      columnKey="name"
+                      sortOrder={sortOrder}
+                    />
+                  </Th>
+                  <Th
+                    width="80px"
+                    position="sticky"
+                    right={0}
+                  />
+                </Tr>
+              </Thead>
+              <Tbody>
+                {tableData.map((partner) => (
+                  <Tr
+                    key={partner.id}
+                    _hover={{
+                      bg: hoverBg,
+                      '& .action-group': { opacity: 1, visibility: 'visible' },
+                    }}
+                    transition="background 0.2s"
+                  >
+                    <Td>{partner.name}</Td>
+                    <Td
+                      p={0}
+                      textAlign="right"
+                      position="sticky"
+                      right={0}
+                    >
+                      <Box
+                        className="action-group"
+                        opacity={0}
+                        visibility="hidden"
+                        transition="all 0.2s"
+                        pr={4}
+                      >
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          leftIcon={<FiEdit2 />}
+                          colorScheme="teal"
+                          bg="white"
+                          onClick={() => onEdit(partner)}
+                        >
+                          {t('common.edit')}
+                        </Button>
+                      </Box>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </TableContainer>
+        </Box>
+      )}
+    </Box>
+  );
+};


### PR DESCRIPTION
Oneshot creation of partner org tab.
Allows creating, editing, and deleting. Functional tested
<img width="2519" height="799" alt="image" src="https://github.com/user-attachments/assets/1366bde2-e639-4c52-b556-40961ef19078" />



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Partners tab to manage partner organizations. Admins can create, edit, search, and delete partners with a simple table and drawer form, fully localized.

- **New Features**
  - New page at `/partners` with a sidebar link; access limited to `Super Admin` and `Admin`.
  - Partners table with search and sort by name, inline edit action, and an empty state.
  - Drawer form for add/edit with required name validation, delete confirmation, and success/error toasts (`POST/PUT/DELETE /partners`).
  - `PartnerOrganizationField` now uses localized label/placeholder, shows the selected org, and supports create-from-field.
  - i18n updates in `en`, `es`, `fr`, and `zh` for the new Partners UI and sidebar.

<sup>Written for commit 28744f6773a4447efb40848713ae7c7c4f4b9ee8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

