### PR TITLE
clearing program form

### DIFF
--- a/client/src/components/dashboard/ProgramForm/ProgramForm.jsx
+++ b/client/src/components/dashboard/ProgramForm/ProgramForm.jsx
@@ -37,7 +37,7 @@ import { isPdfByType } from './programFormHelpers';
 import { ProgramFormMediaTab } from './ProgramFormMediaTab';
 import { ProgramFormOverviewTab } from './ProgramFormOverviewTab';
 import { saveProgramForm } from './programFormSave';
-import { useProgramFormLoad } from './useProgramFormLoad';
+import { emptyFormState, useProgramFormLoad } from './useProgramFormLoad';
 
 export const ProgramForm = ({
   isOpen: isOpenProp,
@@ -120,8 +120,15 @@ export const ProgramForm = ({
   useEffect(() => {
     if (isOpen) {
       setActiveTab('overview');
+      if (!program) {
+        setFormState(emptyFormState);
+        setInitialProgramDirectorIds([]);
+        setInitialInstrumentQuantities({});
+        setInitialCurriculumLinks([]);
+        setInitialGraduated(0);
+      }
     }
-  }, [isOpen]);
+  }, [isOpen, program]);
 
   function handleProgramStatusChange(status) {
     setFormState((prev) => ({ ...prev, status: status || null }));

--- a/client/src/components/dashboard/ProgramForm/useProgramFormLoad.js
+++ b/client/src/components/dashboard/ProgramForm/useProgramFormLoad.js
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import ISO6391 from 'iso-639-1';
 
-const emptyFormState = {
+export const emptyFormState = {
   status: null,
   programName: null,
   partnerOrg: null,


### PR DESCRIPTION
bug bash issue where the program form did not reset after submitting a program

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the program form not resetting after submission. Opening the modal for a new program now clears all fields and returns to the Overview tab.

- **Bug Fixes**
  - Reset to `emptyFormState` when the modal opens without a `program`.
  - Clear initial directors, instrument quantities, curriculum links, and graduated count.
  - Export `emptyFormState` from `useProgramFormLoad` and add `program` to effect deps to ensure correct resets.

<sup>Written for commit 16c1ce8cb76f6883e829666d5180b93721aeff67. Summary will update on new commits. <a href="https://cubic.dev/pr/ctc-uci/gcf/pull/145?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

