### PR TITLE
formatted account dates 

### DIFF
--- a/client/src/components/updates/AccountUpdatesTable.jsx
+++ b/client/src/components/updates/AccountUpdatesTable.jsx
@@ -17,6 +17,7 @@ import {
   Tr,
 } from '@chakra-ui/react';
 
+import { formatRelativeDate } from '@/utils/formatDate';
 import { useTranslation } from 'react-i18next';
 import { FiUser } from 'react-icons/fi';
 
@@ -90,7 +91,9 @@ export const AccountUpdatesTable = ({
         (update.changeType || '').toLowerCase().includes(q) ||
         (update.programName || '').toLowerCase().includes(q) ||
         (update.fullName || '').toLowerCase().includes(q) ||
-        (update.lastModified || '').toLowerCase().includes(q) ||
+        (formatRelativeDate(update.lastModified) || '')
+          .toLowerCase()
+          .includes(q) ||
         `${update.authorFirstName || ''} ${update.authorLastName || ''}`
           .toLowerCase()
           .trim()
@@ -268,7 +271,7 @@ export const AccountUpdatesTable = ({
                         fontSize="sm"
                         color="gray.600"
                       >
-                        {row.lastModified || ''}
+                        {formatRelativeDate(row.lastModified)}
                       </Text>
                     </Td>
                   </Tr>

--- a/client/src/components/updates/UpdatesPage.jsx
+++ b/client/src/components/updates/UpdatesPage.jsx
@@ -19,7 +19,10 @@ import { EmptyStateBadge } from '@/components/badges/EmptyStateBadge';
 import { useTranslation } from 'react-i18next';
 
 import { AccountUpdatesTable } from './AccountUpdatesTable';
-import { programSectionColumns } from './config/updatesColumnConfig';
+import {
+  mediaSectionColumns,
+  programSectionColumns,
+} from './config/updatesColumnConfig';
 import {
   UpdatesFilterPopover,
   UpdatesSearchInput,
@@ -55,6 +58,15 @@ export const UpdatesPage = () => {
 
   const [searchQuery, setSearchQuery] = useState('');
   const [tabIndex, setTabIndex] = useState(0);
+  const [activeFilters, setActiveFilters] = useState([]);
+
+  const handleTabChange = (index) => {
+    setTabIndex(index);
+    setActiveFilters([]);
+  };
+
+  const filterColumns =
+    tabIndex === 1 ? mediaSectionColumns : programSectionColumns;
 
   const handleDownload = () => {
     if (tabIndex === 0) downloadProgramUpdatesAsCsv(programUpdatesData, t);
@@ -106,8 +118,8 @@ export const UpdatesPage = () => {
         onChange={setSearchQuery}
       />
       <UpdatesFilterPopover
-        columns={programSectionColumns}
-        onFilterChange={() => {}}
+        columns={filterColumns}
+        onFilterChange={setActiveFilters}
       />
     </Flex>
   );
@@ -147,7 +159,7 @@ export const UpdatesPage = () => {
       </Flex>
       <Tabs
         index={tabIndex}
-        onChange={setTabIndex}
+        onChange={handleTabChange}
         variant="unstyled"
       >
         <Flex
@@ -200,6 +212,7 @@ export const UpdatesPage = () => {
                   isLoading={isProgramUpdatesLoading}
                   onSave={refetchProgramUpdates}
                   searchQuery={searchQuery}
+                  activeFilters={activeFilters}
                   showStatus
                   showFlagAndType
                   embedded
@@ -225,6 +238,7 @@ export const UpdatesPage = () => {
                   originalData={originalMediaUpdatesData}
                   isLoading={isLoading}
                   searchQuery={searchQuery}
+                  activeFilters={activeFilters}
                   embedded
                 />
               </Box>

--- a/client/src/components/updates/config/useUpdatesPageData.js
+++ b/client/src/components/updates/config/useUpdatesPageData.js
@@ -10,7 +10,8 @@ const mapUpdatesWithFullName = (items) => {
       .filter(Boolean)
       .join(' ')
       .trim();
-    return { ...item, fullName };
+    const status = item.resolved ? 'Resolved' : 'Unresolved';
+    return { ...item, fullName, status };
   });
 };
 

--- a/client/src/contexts/hooks/TableFilter.js
+++ b/client/src/contexts/hooks/TableFilter.js
@@ -14,9 +14,14 @@ const OPERATION_FUNCTIONS = {
   gte: (dataVal, filterVal) => Number(dataVal) >= Number(filterVal),
   lte: (dataVal, filterVal) => Number(dataVal) <= Number(filterVal),
   is: (dataVal, filterVal) =>
-    new Date(dataVal).getTime() === new Date(filterVal).getTime(),
-  before: (dataVal, filterVal) => new Date(dataVal) < new Date(filterVal),
-  after: (dataVal, filterVal) => new Date(dataVal) > new Date(filterVal),
+    new Date(dataVal).toISOString().slice(0, 10) ===
+    new Date(filterVal).toISOString().slice(0, 10),
+  before: (dataVal, filterVal) =>
+    new Date(dataVal).toISOString().slice(0, 10) <
+    new Date(filterVal).toISOString().slice(0, 10),
+  after: (dataVal, filterVal) =>
+    new Date(dataVal).toISOString().slice(0, 10) >
+    new Date(filterVal).toISOString().slice(0, 10),
   contains_item: (dataVal, filterVal) =>
     dataVal.some((item) =>
       str(item).toLowerCase().includes(str(filterVal).toLowerCase())


### PR DESCRIPTION
## Description

In the admin accounts date section  the formats of the date was different then the other tables. 

## Screenshots/Media
Before:
<img width="1073" height="690" alt="Screenshot 2026-04-29 at 1 03 01 PM" src="https://github.com/user-attachments/assets/11134e43-6e3c-4494-902d-5a68f431f177" />

After:
<img width="1073" height="690" alt="Screenshot 2026-04-29 at 1 02 51 PM" src="https://github.com/user-attachments/assets/fdd925fc-ee72-4cfa-a9ec-501cdfe7bbc2" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized date display in the Account Updates table and fixed updates filtering so results are accurate across tabs.

- **Bug Fixes**
  - Show `lastModified` with `formatRelativeDate`, and search uses this formatted value.
  - Fix date filters (`is`, `before`, `after`) to compare by day using ISO `YYYY-MM-DD`.
  - Enable working filters on Updates page: pass `activeFilters`, reset on tab change, and use tab-specific columns.
  - Add `status` ("Resolved"/"Unresolved") to mapped data for consistent filtering and export.

<sup>Written for commit 97278b3a3dc1d10146d146078c3d8f50f9f26847. Summary will update on new commits. <a href="https://cubic.dev/pr/ctc-uci/gcf/pull/148?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

