### PR TITLE
Map IFrame + Zoom

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-router-dom';
 
 import { Account } from './components/accounts/Account';
+import { EmbedTestPage } from './components/map/EmbedTestPage';
 import { Map } from './components/map/Map';
 import { Media } from './components/media/Media';
 import { RegionsPage } from './components/regions/RegionsPage';
@@ -37,6 +38,14 @@ const App = () => {
                 <Route
                   path="/map"
                   element={<Map />}
+                />
+                <Route
+                  path="/embed/map"
+                  element={<Map />}
+                />
+                <Route
+                  path="/embed/test-iframe"
+                  element={<EmbedTestPage />}
                 />
                 <Route
                   path="/"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -40,10 +40,6 @@ const App = () => {
                   element={<Map />}
                 />
                 <Route
-                  path="/embed/map"
-                  element={<Map />}
-                />
-                <Route
                   path="/embed/test-iframe"
                   element={<EmbedTestPage />}
                 />

--- a/client/src/components/map/EmbedTestPage.jsx
+++ b/client/src/components/map/EmbedTestPage.jsx
@@ -1,3 +1,5 @@
+//TODO: remove once embed is on main website
+
 import { Box, Container, Heading, Text } from '@chakra-ui/react';
 
 export const EmbedTestPage = () => {
@@ -20,7 +22,7 @@ export const EmbedTestPage = () => {
           py="2px"
           borderRadius="sm"
         >
-          /embed/map
+          /map
         </Box>{' '}
         route.
       </Text>
@@ -34,7 +36,7 @@ export const EmbedTestPage = () => {
       >
         <Box
           as="iframe"
-          src="/embed/map"
+          src="/map"
           title="GCF Map Embed"
           width="100%"
           height="1100px"

--- a/client/src/components/map/EmbedTestPage.jsx
+++ b/client/src/components/map/EmbedTestPage.jsx
@@ -13,7 +13,7 @@ export const EmbedTestPage = () => {
       >
         This page demonstrates how the GCF map component can be embedded on an
         external website via an iframe pointed at the{' '}
-        <Text
+        <Box
           as="code"
           bg="gray.100"
           px="6px"
@@ -21,7 +21,7 @@ export const EmbedTestPage = () => {
           borderRadius="sm"
         >
           /embed/map
-        </Text>{' '}
+        </Box>{' '}
         route.
       </Text>
 

--- a/client/src/components/map/EmbedTestPage.jsx
+++ b/client/src/components/map/EmbedTestPage.jsx
@@ -1,0 +1,49 @@
+import { Box, Container, Heading, Text } from '@chakra-ui/react';
+
+export const EmbedTestPage = () => {
+  return (
+    <Container
+      maxW="container.xl"
+      py="40px"
+    >
+      <Heading mb="10px">Embedded Map Test Page</Heading>
+      <Text
+        mb="30px"
+        color="gray.600"
+      >
+        This page demonstrates how the GCF map component can be embedded on an
+        external website via an iframe pointed at the{' '}
+        <Text
+          as="code"
+          bg="gray.100"
+          px="6px"
+          py="2px"
+          borderRadius="sm"
+        >
+          /embed/map
+        </Text>{' '}
+        route.
+      </Text>
+
+      <Box
+        w="100%"
+        borderWidth="1px"
+        borderRadius="md"
+        overflow="hidden"
+        boxShadow="sm"
+      >
+        <Box
+          as="iframe"
+          src="/embed/map"
+          title="GCF Map Embed"
+          width="100%"
+          height="1100px"
+          border="0"
+          display="block"
+        />
+      </Box>
+    </Container>
+  );
+};
+
+export default EmbedTestPage;

--- a/client/src/components/map/Map.jsx
+++ b/client/src/components/map/Map.jsx
@@ -6,17 +6,27 @@ import {
   Heading,
   HStack,
   Icon,
+  IconButton,
   Skeleton,
   Text,
+  VStack,
 } from '@chakra-ui/react';
 
 import { useBackendContext } from '@/contexts/hooks/useBackendContext';
 import {
   FaChevronLeft,
   FaChevronRight,
+  FaMinus,
+  FaPlus,
+  FaRedo,
   FaRegArrowAltCircleLeft,
 } from 'react-icons/fa';
-import { ComposableMap, Geographies, Geography } from 'react-simple-maps';
+import {
+  ComposableMap,
+  Geographies,
+  Geography,
+  ZoomableGroup,
+} from 'react-simple-maps';
 
 import CardView, { ProgramCardSkeleton } from './CardView.jsx';
 import ProgramInfoView from './ProgramInfoView.jsx';
@@ -34,7 +44,33 @@ export const Map = () => {
   const [programs, setPrograms] = useState([]);
   const [programsLoading, setProgramsLoading] = useState(false);
   const [selectedProgram, setSelectedProgram] = useState(null);
+  const [position, setPosition] = useState({ coordinates: [0, 0], zoom: 1 });
   const { backend } = useBackendContext();
+
+  const MIN_ZOOM = 1;
+  const MAX_ZOOM = 8;
+
+  const handleZoomIn = () => {
+    setPosition((p) => ({
+      ...p,
+      zoom: Math.min(p.zoom * 1.5, MAX_ZOOM),
+    }));
+  };
+
+  const handleZoomOut = () => {
+    setPosition((p) => ({
+      ...p,
+      zoom: Math.max(p.zoom / 1.5, MIN_ZOOM),
+    }));
+  };
+
+  const handleZoomReset = () => {
+    setPosition({ coordinates: [0, 0], zoom: 1 });
+  };
+
+  const handleMoveEnd = (newPosition) => {
+    setPosition(newPosition);
+  };
 
   const scrollRef = useRef(null);
   const mapContainerRef = useRef(null);
@@ -171,51 +207,101 @@ export const Map = () => {
           }}
         >
           <ComposableMap style={{ height: '700px', width: '100%' }}>
-            <Geographies geography={geoUrl}>
-              {({ geographies }) =>
-                geographies.map((geo) => {
-                  const regionId = getRegionFromIso(geo.id);
-                  const isHovered = regionId && regionId === hoverRegions;
-                  const isSelectedRegion =
-                    regionId != null &&
-                    selectedRegionId != null &&
-                    regionId === selectedRegionId;
-                  return (
-                    <Geography
-                      key={geo.rsmKey}
-                      geography={geo}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleCountry(geo);
-                      }}
-                      onMouseEnter={() => setHoverRegions(regionId)}
-                      onMouseLeave={() => setHoverRegions(null)}
-                      style={{
-                        default: {
-                          fill: isHovered
-                            ? '#868686'
-                            : isSelectedRegion
-                              ? '#636363'
-                              : '#B3B3B3',
-                          outline: 'none',
-                        },
-                        hover: {
-                          fill: regionId ? '#868686' : '#B3B3B3',
-                          outline: 'none',
-                          cursor: regionId ? 'pointer' : 'default',
-                        },
-                        pressed: {
-                          fill: regionId ? '#868686' : '#B3B3B3',
-                          outline: 'none',
-                          cursor: regionId ? 'pointer' : 'default',
-                        },
-                      }}
-                    />
-                  );
-                })
-              }
-            </Geographies>
+            <ZoomableGroup
+              zoom={position.zoom}
+              center={position.coordinates}
+              minZoom={MIN_ZOOM}
+              maxZoom={MAX_ZOOM}
+              onMoveEnd={handleMoveEnd}
+            >
+              <Geographies geography={geoUrl}>
+                {({ geographies }) =>
+                  geographies.map((geo) => {
+                    const regionId = getRegionFromIso(geo.id);
+                    const isHovered = regionId && regionId === hoverRegions;
+                    const isSelectedRegion =
+                      regionId != null &&
+                      selectedRegionId != null &&
+                      regionId === selectedRegionId;
+                    return (
+                      <Geography
+                        key={geo.rsmKey}
+                        geography={geo}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleCountry(geo);
+                        }}
+                        onMouseEnter={() => setHoverRegions(regionId)}
+                        onMouseLeave={() => setHoverRegions(null)}
+                        style={{
+                          default: {
+                            fill: isHovered
+                              ? '#868686'
+                              : isSelectedRegion
+                                ? '#636363'
+                                : '#B3B3B3',
+                            outline: 'none',
+                          },
+                          hover: {
+                            fill: regionId ? '#868686' : '#B3B3B3',
+                            outline: 'none',
+                            cursor: regionId ? 'pointer' : 'default',
+                          },
+                          pressed: {
+                            fill: regionId ? '#868686' : '#B3B3B3',
+                            outline: 'none',
+                            cursor: regionId ? 'pointer' : 'default',
+                          },
+                        }}
+                      />
+                    );
+                  })
+                }
+              </Geographies>
+            </ZoomableGroup>
           </ComposableMap>
+
+          <VStack
+            position="absolute"
+            top="12px"
+            right="12px"
+            spacing={1}
+            zIndex={11}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <IconButton
+              aria-label="Zoom in"
+              icon={<FaPlus />}
+              size="sm"
+              bg="white"
+              color="gray.700"
+              boxShadow="md"
+              _hover={{ bg: 'gray.100' }}
+              isDisabled={position.zoom >= MAX_ZOOM}
+              onClick={handleZoomIn}
+            />
+            <IconButton
+              aria-label="Zoom out"
+              icon={<FaMinus />}
+              size="sm"
+              bg="white"
+              color="gray.700"
+              boxShadow="md"
+              _hover={{ bg: 'gray.100' }}
+              isDisabled={position.zoom <= MIN_ZOOM}
+              onClick={handleZoomOut}
+            />
+            <IconButton
+              aria-label="Reset zoom"
+              icon={<FaRedo />}
+              size="sm"
+              bg="white"
+              color="gray.700"
+              boxShadow="md"
+              _hover={{ bg: 'gray.100' }}
+              onClick={handleZoomReset}
+            />
+          </VStack>
 
           {hoverRegions && regionMap[hoverRegions] && (
             <Box


### PR DESCRIPTION
## Description

implements the map iframe + zoom

## Screenshots/Media

<img width="2742" height="1478" alt="image" src="https://github.com/user-attachments/assets/3e6aeecd-81ad-4f17-b84f-01f505bc39f8" />

https://github.com/user-attachments/assets/1dfd1744-a852-4b8d-9068-fec1284462cc

## Issues
Closes #141 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an embeddable map with zoom/pan controls. Addresses #141 by letting sites iframe the `/map` route and adding on-canvas zoom with reset.

- New Features
  - Embed demo page at `/embed/test-iframe` that iframes `/map` (no separate `/embed/map` route).
  - Zoom/pan via `ZoomableGroup` from `react-simple-maps` (min 1, max 8).
  - On-canvas +/−/reset controls; disabled at limits; clicks don’t block selection.

- Bug Fixes
  - Fixed nested `Text` usage on the embed test page to avoid invalid markup.

<sup>Written for commit 792c34b03aca42db9d96e4439010efabadbf983f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

