### PR TITLE
Account Tab form Profile Picture editing

### DIFF
--- a/client/src/components/accounts/AccountForm/AccountFormDrawer.jsx
+++ b/client/src/components/accounts/AccountForm/AccountFormDrawer.jsx
@@ -22,10 +22,12 @@ import {
   Select,
   Spacer,
   Text,
+  useDisclosure,
   VStack,
 } from '@chakra-ui/react';
 
 import { DirectorAvatar } from '@/components/dashboard/ProgramForm/DirectorAvatar';
+import { MediaUploadModal } from '@/components/media/MediaUploadModal';
 import { useTranslation } from 'react-i18next';
 import {
   FiCamera,
@@ -61,204 +63,136 @@ export const AccountFormDrawer = ({
   onCancel,
   onSave,
   isLoading,
+  profilePictureUrl = '',
+  onProfilePictureUpload,
 }) => {
   const { t } = useTranslation();
+  const {
+    isOpen: isProfilePictureModalOpen,
+    onOpen: onProfilePictureModalOpen,
+    onClose: onProfilePictureModalClose,
+  } = useDisclosure();
 
   return (
-    <Drawer
-      isOpen={isOpen}
-      placement="right"
-      onClose={onClose}
-      size="lg"
-    >
-      <DrawerOverlay />
-      <DrawerContent
-        w={isFullScreen ? '100vw' : '50vw'}
-        maxW={isFullScreen ? '100vw' : '50vw'}
-        display="flex"
-        flexDirection="column"
+    <>
+      <Drawer
+        isOpen={isOpen}
+        placement="right"
+        onClose={onClose}
+        size="lg"
       >
-        <Flex
-          align="center"
-          px={4}
-          pt={3}
-          pb={2}
+        <DrawerOverlay />
+        <DrawerContent
+          w={isFullScreen ? '100vw' : '50vw'}
+          maxW={isFullScreen ? '100vw' : '50vw'}
+          display="flex"
+          flexDirection="column"
         >
-          <IconButton
-            icon={isFullScreen ? <FiMinimize2 /> : <FiMaximize2 />}
-            aria-label={
-              isFullScreen
-                ? t('fullscreenFlyout.minimize')
-                : t('fullscreenFlyout.expand')
-            }
-            variant="ghost"
-            size="sm"
-            onClick={onToggleFullScreen}
-          />
-          <Text
-            fontWeight="bold"
-            fontSize="xl"
+          <Flex
+            align="center"
+            px={4}
+            pt={3}
+            pb={2}
+          >
+            <IconButton
+              icon={isFullScreen ? <FiMinimize2 /> : <FiMaximize2 />}
+              aria-label={
+                isFullScreen
+                  ? t('fullscreenFlyout.minimize')
+                  : t('fullscreenFlyout.expand')
+              }
+              variant="ghost"
+              size="sm"
+              onClick={onToggleFullScreen}
+            />
+            <Text
+              fontWeight="bold"
+              fontSize="xl"
+              flex={1}
+              textAlign="center"
+            >
+              {t('accountForm.drawerTitle')}
+            </Text>
+            <Box w="32px" />
+          </Flex>
+          <Divider borderColor="gray.300" />
+
+          <DrawerBody
             flex={1}
-            textAlign="center"
+            overflowY="auto"
+            py={6}
+            px={8}
           >
-            {t('accountForm.drawerTitle')}
-          </Text>
-          <Box w="32px" />
-        </Flex>
-        <Divider borderColor="gray.300" />
-
-        <DrawerBody
-          flex={1}
-          overflowY="auto"
-          py={6}
-          px={8}
-        >
-          <VStack
-            spacing={6}
-            align="stretch"
-          >
-            <Heading
-              as="h3"
-              size="md"
-              fontWeight="semibold"
+            <VStack
+              spacing={6}
+              align="stretch"
             >
-              {t('accountForm.userProfile')}
-            </Heading>
-
-            <Box>
-              <Text
-                color={LABEL_COLOR}
-                fontSize="sm"
-                fontWeight="medium"
-                mb={3}
+              <Heading
+                as="h3"
+                size="md"
+                fontWeight="semibold"
               >
-                {t('accountForm.profilePhoto')}
-              </Text>
-              <Flex justify="center">
-                <Box
-                  position="relative"
-                  display="inline-block"
+                {t('accountForm.userProfile')}
+              </Heading>
+
+              <Box>
+                <Text
+                  color={LABEL_COLOR}
+                  fontSize="sm"
+                  fontWeight="medium"
+                  mb={3}
                 >
-                  <Image
-                    src={DEFAULT_PROFILE_IMAGE}
-                    boxSize="180px"
-                    borderRadius="full"
-                    fit="cover"
-                    alt={t('accountForm.profileAlt')}
-                    bg="gray.200"
-                    fallback={
-                      <Avatar
-                        size="2xl"
-                        name={
-                          formData.first_name || formData.last_name
-                            ? `${formData.first_name} ${formData.last_name}`
-                            : undefined
-                        }
-                        bg="gray.300"
-                        w="180px"
-                        h="180px"
+                  {t('accountForm.profilePhoto')}
+                </Text>
+                <Flex justify="center">
+                  <Box
+                    position="relative"
+                    display="inline-block"
+                  >
+                    <Image
+                      src={profilePictureUrl || DEFAULT_PROFILE_IMAGE}
+                      boxSize="180px"
+                      borderRadius="full"
+                      fit="cover"
+                      alt={t('accountForm.profileAlt')}
+                      bg="gray.200"
+                      fallback={
+                        <Avatar
+                          size="2xl"
+                          name={
+                            formData.first_name || formData.last_name
+                              ? `${formData.first_name} ${formData.last_name}`
+                              : undefined
+                          }
+                          bg="gray.300"
+                          w="180px"
+                          h="180px"
+                        />
+                      }
+                    />
+                    {targetUserId && (
+                      <IconButton
+                        icon={<FiCamera />}
+                        aria-label={t('profile.uploadPhoto')}
+                        borderRadius="full"
+                        size="sm"
+                        bg="white"
+                        boxShadow="md"
+                        position="absolute"
+                        bottom={2}
+                        right={2}
+                        _hover={{ bg: 'gray.100' }}
+                        onClick={onProfilePictureModalOpen}
                       />
-                    }
-                  />
-                  <IconButton
-                    icon={<FiCamera />}
-                    aria-label={t('profile.uploadPhoto')}
-                    borderRadius="full"
-                    size="sm"
-                    bg="white"
-                    boxShadow="md"
-                    position="absolute"
-                    bottom={2}
-                    right={2}
-                    _hover={{ bg: 'gray.100' }}
-                  />
-                </Box>
-              </Flex>
-            </Box>
+                    )}
+                  </Box>
+                </Flex>
+              </Box>
 
-            <Grid
-              templateColumns="repeat(2, 1fr)"
-              gap={4}
-            >
-              <GridItem>
-                <FormControl>
-                  <FormLabel
-                    color={LABEL_COLOR}
-                    fontSize="sm"
-                    fontWeight="medium"
-                  >
-                    {t('accountForm.fieldFirstName')}{' '}
-                    <Text
-                      as="span"
-                      color="red.500"
-                    >
-                      *
-                    </Text>
-                  </FormLabel>
-                  <Input
-                    name="first_name"
-                    placeholder={t('accountForm.fieldFirstName')}
-                    value={formData.first_name}
-                    onChange={onChange}
-                    {...errorBorderProps('first_name')}
-                  />
-                </FormControl>
-              </GridItem>
-              <GridItem>
-                <FormControl>
-                  <FormLabel
-                    color={LABEL_COLOR}
-                    fontSize="sm"
-                    fontWeight="medium"
-                  >
-                    {t('accountForm.fieldLastName')}{' '}
-                    <Text
-                      as="span"
-                      color="red.500"
-                    >
-                      *
-                    </Text>
-                  </FormLabel>
-                  <Input
-                    name="last_name"
-                    placeholder={t('accountForm.fieldLastName')}
-                    value={formData.last_name}
-                    onChange={onChange}
-                    {...errorBorderProps('last_name')}
-                  />
-                </FormControl>
-              </GridItem>
-            </Grid>
-
-            <Grid
-              templateColumns="repeat(2, 1fr)"
-              gap={4}
-            >
-              <GridItem>
-                <FormControl>
-                  <FormLabel
-                    color={LABEL_COLOR}
-                    fontSize="sm"
-                    fontWeight="medium"
-                  >
-                    {t('accountForm.fieldEmail')}{' '}
-                    <Text
-                      as="span"
-                      color="red.500"
-                    >
-                      *
-                    </Text>
-                  </FormLabel>
-                  <Input
-                    name="email"
-                    placeholder={t('accountForm.emailAddressPlaceholder')}
-                    value={formData.email}
-                    onChange={onChange}
-                    {...errorBorderProps('email')}
-                  />
-                </FormControl>
-              </GridItem>
-              {targetUserId ? (
+              <Grid
+                templateColumns="repeat(2, 1fr)"
+                gap={4}
+              >
                 <GridItem>
                   <FormControl>
                     <FormLabel
@@ -266,262 +200,349 @@ export const AccountFormDrawer = ({
                       fontSize="sm"
                       fontWeight="medium"
                     >
-                      {t('accountForm.fieldPassword')}
+                      {t('accountForm.fieldFirstName')}{' '}
+                      <Text
+                        as="span"
+                        color="red.500"
+                      >
+                        *
+                      </Text>
                     </FormLabel>
-                    <InputGroup>
-                      <Input
-                        name="password"
-                        type={showPassword ? 'text' : 'password'}
-                        autoComplete="new-password"
-                        placeholder={t('accountForm.passwordLeaveBlank')}
-                        value={formData.password}
-                        onChange={onChange}
-                        {...errorBorderProps('password')}
-                      />
-                      <InputRightElement>
-                        <IconButton
-                          icon={showPassword ? <FiEye /> : <FiEyeOff />}
-                          aria-label={t('profile.togglePassword')}
-                          variant="ghost"
-                          size="sm"
-                          onClick={onToggleShowPassword}
-                        />
-                      </InputRightElement>
-                    </InputGroup>
+                    <Input
+                      name="first_name"
+                      placeholder={t('accountForm.fieldFirstName')}
+                      value={formData.first_name}
+                      onChange={onChange}
+                      {...errorBorderProps('first_name')}
+                    />
                   </FormControl>
                 </GridItem>
-              ) : (
                 <GridItem>
-                  <Text
-                    fontSize="sm"
-                    color="gray.600"
-                    pt={8}
-                  >
-                    {t('accountForm.passwordEmailNote')}
-                  </Text>
+                  <FormControl>
+                    <FormLabel
+                      color={LABEL_COLOR}
+                      fontSize="sm"
+                      fontWeight="medium"
+                    >
+                      {t('accountForm.fieldLastName')}{' '}
+                      <Text
+                        as="span"
+                        color="red.500"
+                      >
+                        *
+                      </Text>
+                    </FormLabel>
+                    <Input
+                      name="last_name"
+                      placeholder={t('accountForm.fieldLastName')}
+                      value={formData.last_name}
+                      onChange={onChange}
+                      {...errorBorderProps('last_name')}
+                    />
+                  </FormControl>
                 </GridItem>
-              )}
-            </Grid>
+              </Grid>
 
-            <Heading
-              as="h3"
-              size="md"
-              fontWeight="semibold"
-              mt={4}
-            >
-              {t('accountForm.roleAccess')}
-            </Heading>
-
-            <FormControl>
-              <FormLabel
-                color={LABEL_COLOR}
-                fontSize="sm"
-                fontWeight="medium"
+              <Grid
+                templateColumns="repeat(2, 1fr)"
+                gap={4}
               >
-                {t('accountForm.fieldRole')}{' '}
-                <Text
-                  as="span"
-                  color="red.500"
-                >
-                  *
-                </Text>
-              </FormLabel>
-              <Select
-                name="role"
-                placeholder={t('accountForm.rolePlaceholder')}
-                value={formData.role}
-                onChange={onChange}
-                {...errorBorderProps('role')}
-              >
-                {viewerRole === 'Super Admin' && (
-                  <option value="Admin">{t('signup.roleAdmin')}</option>
-                )}
-                {(viewerRole === 'Admin' || viewerRole === 'Super Admin') && (
-                  <option value="Regional Director">
-                    {t('signup.roleRegionalDirector')}
-                  </option>
-                )}
-                <option value="Program Director">
-                  {t('signup.roleProgramDirector')}
-                </option>
-              </Select>
-            </FormControl>
-
-            {formData.role === 'Program Director' && (
-              <FormControl>
-                <FormLabel
-                  color={LABEL_COLOR}
-                  fontSize="sm"
-                  fontWeight="medium"
-                >
-                  {t('accountForm.assignedProgram')}
-                </FormLabel>
-                <Select
-                  placeholder={t('accountForm.programNamePlaceholder')}
-                  value={
-                    formData.programs.length > 0
-                      ? String(formData.programs[0].id)
-                      : ''
-                  }
-                  onChange={(e) => {
-                    const selectedProgramId = e.target.value;
-                    if (!selectedProgramId) return;
-
-                    const selectedProgram = currentPrograms?.find(
-                      (p) => String(p.id) === String(selectedProgramId)
-                    );
-
-                    if (selectedProgram) {
-                      setFormData((prev) => ({
-                        ...prev,
-                        programs: [selectedProgram],
-                      }));
-                    }
-                  }}
-                >
-                  {currentPrograms?.map((program) => (
-                    <option
-                      key={program.id}
-                      value={program.id}
+                <GridItem>
+                  <FormControl>
+                    <FormLabel
+                      color={LABEL_COLOR}
+                      fontSize="sm"
+                      fontWeight="medium"
                     >
-                      {program.name}
-                    </option>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
-
-            {formData.role === 'Regional Director' && (
-              <FormControl>
-                <FormLabel
-                  color={LABEL_COLOR}
-                  fontSize="sm"
-                  fontWeight="medium"
-                >
-                  {t('accountForm.assignedRegion')}
-                </FormLabel>
-                <Select
-                  placeholder={t('accountForm.regionNamePlaceholder')}
-                  value={
-                    formData.regions.length > 0
-                      ? String(formData.regions[0].id)
-                      : ''
-                  }
-                  onChange={(e) => {
-                    const selectedRegionId = e.target.value;
-                    if (!selectedRegionId) return;
-
-                    const selectedRegion = currentRegions?.find(
-                      (r) => String(r.id) === String(selectedRegionId)
-                    );
-
-                    if (selectedRegion) {
-                      setFormData((prev) => ({
-                        ...prev,
-                        regions: [selectedRegion],
-                      }));
-                    }
-                  }}
-                >
-                  {currentRegions?.map((region) => (
-                    <option
-                      key={region.id}
-                      value={region.id}
+                      {t('accountForm.fieldEmail')}{' '}
+                      <Text
+                        as="span"
+                        color="red.500"
+                      >
+                        *
+                      </Text>
+                    </FormLabel>
+                    <Input
+                      name="email"
+                      placeholder={t('accountForm.emailAddressPlaceholder')}
+                      value={formData.email}
+                      onChange={onChange}
+                      {...errorBorderProps('email')}
+                    />
+                  </FormControl>
+                </GridItem>
+                {targetUserId ? (
+                  <GridItem>
+                    <FormControl>
+                      <FormLabel
+                        color={LABEL_COLOR}
+                        fontSize="sm"
+                        fontWeight="medium"
+                      >
+                        {t('accountForm.fieldPassword')}
+                      </FormLabel>
+                      <InputGroup>
+                        <Input
+                          name="password"
+                          type={showPassword ? 'text' : 'password'}
+                          autoComplete="new-password"
+                          placeholder={t('accountForm.passwordLeaveBlank')}
+                          value={formData.password}
+                          onChange={onChange}
+                          {...errorBorderProps('password')}
+                        />
+                        <InputRightElement>
+                          <IconButton
+                            icon={showPassword ? <FiEye /> : <FiEyeOff />}
+                            aria-label={t('profile.togglePassword')}
+                            variant="ghost"
+                            size="sm"
+                            onClick={onToggleShowPassword}
+                          />
+                        </InputRightElement>
+                      </InputGroup>
+                    </FormControl>
+                  </GridItem>
+                ) : (
+                  <GridItem>
+                    <Text
+                      fontSize="sm"
+                      color="gray.600"
+                      pt={8}
                     >
-                      {region.name}
-                    </option>
-                  ))}
-                </Select>
-              </FormControl>
-            )}
+                      {t('accountForm.passwordEmailNote')}
+                    </Text>
+                  </GridItem>
+                )}
+              </Grid>
 
-            {formData.role === 'Program Director' && (
               <Heading
                 as="h3"
                 size="md"
                 fontWeight="semibold"
                 mt={4}
               >
-                {t('accountForm.additionalInfo')}
+                {t('accountForm.roleAccess')}
               </Heading>
-            )}
 
-            <Box mt={4}>
-              <Text
-                color={LABEL_COLOR}
-                fontSize="sm"
-                fontWeight="medium"
-                mb={2}
+              <FormControl>
+                <FormLabel
+                  color={LABEL_COLOR}
+                  fontSize="sm"
+                  fontWeight="medium"
+                >
+                  {t('accountForm.fieldRole')}{' '}
+                  <Text
+                    as="span"
+                    color="red.500"
+                  >
+                    *
+                  </Text>
+                </FormLabel>
+                <Select
+                  name="role"
+                  placeholder={t('accountForm.rolePlaceholder')}
+                  value={formData.role}
+                  onChange={onChange}
+                  {...errorBorderProps('role')}
+                >
+                  {viewerRole === 'Super Admin' && (
+                    <option value="Admin">{t('signup.roleAdmin')}</option>
+                  )}
+                  {(viewerRole === 'Admin' || viewerRole === 'Super Admin') && (
+                    <option value="Regional Director">
+                      {t('signup.roleRegionalDirector')}
+                    </option>
+                  )}
+                  <option value="Program Director">
+                    {t('signup.roleProgramDirector')}
+                  </option>
+                </Select>
+              </FormControl>
+
+              {formData.role === 'Program Director' && (
+                <FormControl>
+                  <FormLabel
+                    color={LABEL_COLOR}
+                    fontSize="sm"
+                    fontWeight="medium"
+                  >
+                    {t('accountForm.assignedProgram')}
+                  </FormLabel>
+                  <Select
+                    placeholder={t('accountForm.programNamePlaceholder')}
+                    value={
+                      formData.programs.length > 0
+                        ? String(formData.programs[0].id)
+                        : ''
+                    }
+                    onChange={(e) => {
+                      const selectedProgramId = e.target.value;
+                      if (!selectedProgramId) return;
+
+                      const selectedProgram = currentPrograms?.find(
+                        (p) => String(p.id) === String(selectedProgramId)
+                      );
+
+                      if (selectedProgram) {
+                        setFormData((prev) => ({
+                          ...prev,
+                          programs: [selectedProgram],
+                        }));
+                      }
+                    }}
+                  >
+                    {currentPrograms?.map((program) => (
+                      <option
+                        key={program.id}
+                        value={program.id}
+                      >
+                        {program.name}
+                      </option>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+
+              {formData.role === 'Regional Director' && (
+                <FormControl>
+                  <FormLabel
+                    color={LABEL_COLOR}
+                    fontSize="sm"
+                    fontWeight="medium"
+                  >
+                    {t('accountForm.assignedRegion')}
+                  </FormLabel>
+                  <Select
+                    placeholder={t('accountForm.regionNamePlaceholder')}
+                    value={
+                      formData.regions.length > 0
+                        ? String(formData.regions[0].id)
+                        : ''
+                    }
+                    onChange={(e) => {
+                      const selectedRegionId = e.target.value;
+                      if (!selectedRegionId) return;
+
+                      const selectedRegion = currentRegions?.find(
+                        (r) => String(r.id) === String(selectedRegionId)
+                      );
+
+                      if (selectedRegion) {
+                        setFormData((prev) => ({
+                          ...prev,
+                          regions: [selectedRegion],
+                        }));
+                      }
+                    }}
+                  >
+                    {currentRegions?.map((region) => (
+                      <option
+                        key={region.id}
+                        value={region.id}
+                      >
+                        {region.name}
+                      </option>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+
+              {formData.role === 'Program Director' && (
+                <Heading
+                  as="h3"
+                  size="md"
+                  fontWeight="semibold"
+                  mt={4}
+                >
+                  {t('accountForm.additionalInfo')}
+                </Heading>
+              )}
+
+              <Box mt={4}>
+                <Text
+                  color={LABEL_COLOR}
+                  fontSize="sm"
+                  fontWeight="medium"
+                  mb={2}
+                >
+                  {t('accountForm.createdBy')}
+                </Text>
+                <HStack spacing={2}>
+                  {isNewAccount ? (
+                    <Avatar
+                      size="sm"
+                      name={createdByName}
+                      src={creatorPhotoUrl || undefined}
+                      bg="teal.500"
+                      color="white"
+                    />
+                  ) : createdByPicture ? (
+                    <DirectorAvatar
+                      picture={createdByPicture}
+                      name={createdByName}
+                      boxSize="32px"
+                    />
+                  ) : (
+                    <Avatar
+                      size="sm"
+                      name={createdByName}
+                      bg="teal.500"
+                      color="white"
+                    />
+                  )}
+                  <Text fontSize="sm">{createdByName}</Text>
+                </HStack>
+              </Box>
+            </VStack>
+          </DrawerBody>
+
+          <Divider borderColor="gray.200" />
+          <Flex
+            align="center"
+            px={8}
+            py={4}
+            bg="white"
+          >
+            {targetUserId ? (
+              <Button
+                variant="ghost"
+                color="red.500"
+                leftIcon={<FiTrash2 />}
+                onClick={onDeleteClick}
+                fontWeight="normal"
               >
-                {t('accountForm.createdBy')}
-              </Text>
-              <HStack spacing={2}>
-                {isNewAccount ? (
-                  <Avatar
-                    size="sm"
-                    name={createdByName}
-                    src={creatorPhotoUrl || undefined}
-                    bg="teal.500"
-                    color="white"
-                  />
-                ) : createdByPicture ? (
-                  <DirectorAvatar
-                    picture={createdByPicture}
-                    name={createdByName}
-                    boxSize="32px"
-                  />
-                ) : (
-                  <Avatar
-                    size="sm"
-                    name={createdByName}
-                    bg="teal.500"
-                    color="white"
-                  />
-                )}
-                <Text fontSize="sm">{createdByName}</Text>
-              </HStack>
-            </Box>
-          </VStack>
-        </DrawerBody>
-
-        <Divider borderColor="gray.200" />
-        <Flex
-          align="center"
-          px={8}
-          py={4}
-          bg="white"
-        >
-          {targetUserId ? (
-            <Button
-              variant="ghost"
-              color="red.500"
-              leftIcon={<FiTrash2 />}
-              onClick={onDeleteClick}
-              fontWeight="normal"
-            >
-              {t('common.delete')}
-            </Button>
-          ) : null}
-          <Spacer />
-          <HStack spacing={3}>
-            <Button
-              variant="outline"
-              onClick={onCancel}
-            >
-              {t('common.cancel')}
-            </Button>
-            <Button
-              bg="teal.500"
-              color="white"
-              _hover={{ bg: 'teal.600' }}
-              onClick={onSave}
-              isLoading={isLoading}
-            >
-              {t('common.save')}
-            </Button>
-          </HStack>
-        </Flex>
-      </DrawerContent>
-    </Drawer>
+                {t('common.delete')}
+              </Button>
+            ) : null}
+            <Spacer />
+            <HStack spacing={3}>
+              <Button
+                variant="outline"
+                onClick={onCancel}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                bg="teal.500"
+                color="white"
+                _hover={{ bg: 'teal.600' }}
+                onClick={onSave}
+                isLoading={isLoading}
+              >
+                {t('common.save')}
+              </Button>
+            </HStack>
+          </Flex>
+        </DrawerContent>
+      </Drawer>
+      <MediaUploadModal
+        isOpen={isProfilePictureModalOpen}
+        onClose={onProfilePictureModalClose}
+        onUploadComplete={onProfilePictureUpload}
+        formOrigin="profile"
+        accept={{ 'image/*': [] }}
+      />
+    </>
   );
 };

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -32,6 +32,8 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
   const [validationErrors, setValidationErrors] = useState({});
   const [currentPrograms, setCurrentPrograms] = useState(null);
   const [currentRegions, setCurrentRegions] = useState(null);
+  const [profilePictureUrl, setProfilePictureUrl] = useState('');
+  const [profilePictureKey, setProfilePictureKey] = useState('');
 
   const exitModal = useDisclosure();
   const deleteModal = useDisclosure();
@@ -59,6 +61,8 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
     setValidationErrors({});
     setShowPassword(false);
     setIsFullScreen(false);
+    setProfilePictureUrl('');
+    setProfilePictureKey('');
 
     if (!targetUser) {
       const newState = { ...INITIAL_FORM_STATE, programs: [], regions: [] };
@@ -91,6 +95,21 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
           }
         };
         fetchEmail();
+      }
+
+      if (targetUser.picture) {
+        const fetchPictureUrl = async () => {
+          try {
+            const urlResponse = await backend.get(
+              `/images/url/${encodeURIComponent(targetUser.picture)}`
+            );
+            setProfilePictureUrl(urlResponse.data.url || '');
+            setProfilePictureKey(targetUser.picture);
+          } catch {
+            // picture unavailable — leave blank
+          }
+        };
+        fetchPictureUrl();
       }
     }
   }, [targetUser, targetUserId, backend, isOpen]);
@@ -258,6 +277,54 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
       await backend.post('/accountChange', payload);
     } catch (err) {
       console.error('Failed to log account change:', err);
+    }
+  };
+
+  const handleProfilePictureUpload = async (uploadedFiles) => {
+    if (!uploadedFiles?.length) return;
+
+    const key = uploadedFiles[0].s3_key;
+
+    try {
+      const urlResponse = await backend.get(
+        `/images/url/${encodeURIComponent(key)}`
+      );
+      const nextUrl = urlResponse.data.url || '';
+      const prevKey = profilePictureKey || null;
+
+      if (targetUserId) {
+        await backend.post('/images/profile-picture', {
+          key,
+          userId: targetUserId,
+        });
+
+        await logAccountChange({
+          user_id: String(targetUserId),
+          author_id: String(userId),
+          change_type: 'Update',
+          old_values: {
+            first_name: formData.first_name,
+            last_name: formData.last_name,
+            email: formData.email,
+            picture: prevKey,
+            bio: '',
+          },
+          new_values: {
+            first_name: formData.first_name,
+            last_name: formData.last_name,
+            email: formData.email,
+            picture: key,
+            bio: '',
+          },
+          resolved: false,
+          last_modified: new Date().toISOString(),
+        });
+      }
+
+      setProfilePictureKey(key);
+      setProfilePictureUrl(nextUrl);
+    } catch (err) {
+      console.error('Error saving profile picture:', err);
     }
   };
 
@@ -469,6 +536,8 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
         onCancel={handleCloseWithCheck}
         onSave={handleSaveClick}
         isLoading={isLoading}
+        profilePictureUrl={profilePictureUrl}
+        onProfilePictureUpload={handleProfilePictureUpload}
       />
 
       <AccountFormExitModal

--- a/client/src/components/profile/ProfileView.jsx
+++ b/client/src/components/profile/ProfileView.jsx
@@ -496,6 +496,7 @@ export const ProfileView = (props) => {
         onClose={onClose}
         onUploadComplete={handleProfilePictureUpload}
         formOrigin="profile"
+        accept={{ 'image/*': [] }}
       />
 
       <ChangePasswordModal


### PR DESCRIPTION
## Description
Allows admin and regional director to replace users' profile pictures using media upload modal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Admins and Regional Directors can now update a user's profile picture from the Account tab using `MediaUploadModal`. The new image is saved, the preview updates immediately, and an audit log is recorded.

- **New Features**
  - Integrated `MediaUploadModal` into `AccountFormDrawer`; camera button on avatar opens it (images only).
  - Loads and displays the current picture via `/images/url/:key`, with a fallback avatar.
  - Upload handler saves the new key via `/images/profile-picture`, refreshes the preview URL, and logs the change.
  - Passed `profilePictureUrl` and `onProfilePictureUpload` to the drawer and gated editing to existing users; `ProfileView` now also restricts uploads to images.

<sup>Written for commit 0ad7ecb8d3020a0c1cd8214e520cfe5409e0b3ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

