### PR TITLE
feat: add delete button with confirmation modal for partner organization

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -362,6 +362,9 @@
     "deleteTitle": "Are you sure you want to delete this program?",
     "deleteDesc": "This action cannot be undone.",
     "deleteProgram": "Delete Program",
+    "deletePartnerOrgTitle": "Remove Partner Organization?",
+    "deletePartnerOrgDesc": "This will remove the partner organization from this program.",
+    "deletePartnerOrg": "Remove",
     "saveSuccess": "Program saved successfully.",
     "saveError": "Failed to save program."
   },

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -362,6 +362,9 @@
     "deleteTitle": "¿Seguro que quieres eliminar este programa?",
     "deleteDesc": "Esta acción no se puede deshacer.",
     "deleteProgram": "Eliminar programa",
+    "deletePartnerOrgTitle": "¿Eliminar la organización asociada?",
+    "deletePartnerOrgDesc": "Esto eliminará la organización asociada de este programa.",
+    "deletePartnerOrg": "Eliminar",
     "saveSuccess": "Programa guardado correctamente.",
     "saveError": "Error al guardar el programa."
   },

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -362,6 +362,9 @@
     "deleteTitle": "Voulez-vous vraiment supprimer ce programme ?",
     "deleteDesc": "Cette action est irréversible.",
     "deleteProgram": "Supprimer le programme",
+    "deletePartnerOrgTitle": "Retirer l'organisation partenaire ?",
+    "deletePartnerOrgDesc": "Cette action retirera l'organisation partenaire de ce programme.",
+    "deletePartnerOrg": "Retirer",
     "saveSuccess": "Programme enregistré avec succès.",
     "saveError": "Échec de l'enregistrement du programme."
   },

--- a/client/public/locales/zh/translation.json
+++ b/client/public/locales/zh/translation.json
@@ -362,6 +362,9 @@
     "deleteTitle": "确定要删除此项目吗？",
     "deleteDesc": "此操作无法撤销。",
     "deleteProgram": "删除项目",
+    "deletePartnerOrgTitle": "移除合作组织？",
+    "deletePartnerOrgDesc": "这将从该项目中移除合作组织。",
+    "deletePartnerOrg": "移除",
     "saveSuccess": "项目保存成功。",
     "saveError": "项目保存失败。"
   },

--- a/client/src/components/partners/PartnerOrganizationField.jsx
+++ b/client/src/components/partners/PartnerOrganizationField.jsx
@@ -1,16 +1,35 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { Box, FormControl, FormLabel, Text } from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  HStack,
+  IconButton,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
 
 import { SearchInput } from '@/components/common/SearchInput';
 import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { useTranslation } from 'react-i18next';
 
 export function PartnerOrganizationField({
   valueId,
   onChangeId,
   label = 'Partner Organization',
 }) {
+  const { t } = useTranslation();
   const { backend } = useBackendContext();
+  const deleteDisclosure = useDisclosure();
   const [partnerOrgs, setPartnerOrgs] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -89,15 +108,72 @@ export function PartnerOrganizationField({
           placeholder="Enter Partner Organization"
         />
         {selected && (
-          <Text
-            fontSize="sm"
-            color="gray.600"
+          <HStack
             mt={1}
+            spacing={1}
           >
-            Selected: {selected.name}
-          </Text>
+            <Text
+              fontSize="sm"
+              color="gray.600"
+            >
+              Selected: {selected.name}
+            </Text>
+            <IconButton
+              aria-label={t('programForm.deletePartnerOrg')}
+              icon={<DeleteIcon />}
+              size="xs"
+              variant="ghost"
+              colorScheme="red"
+              onClick={deleteDisclosure.onOpen}
+            />
+          </HStack>
         )}
       </Box>
+
+      <Modal
+        isOpen={deleteDisclosure.isOpen}
+        onClose={deleteDisclosure.onClose}
+        isCentered
+      >
+        <ModalOverlay />
+        <ModalContent
+          borderRadius="md"
+          p={2}
+        >
+          <ModalHeader
+            fontSize="lg"
+            fontWeight="semibold"
+          >
+            {t('programForm.deletePartnerOrgTitle')}
+          </ModalHeader>
+
+          <ModalBody color="gray.600">
+            {t('programForm.deletePartnerOrgDesc')}
+          </ModalBody>
+
+          <ModalFooter
+            justifyContent="center"
+            gap={3}
+          >
+            <Button
+              onClick={deleteDisclosure.onClose}
+              bg="gray.100"
+              _hover={{ bg: 'gray.200' }}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              colorScheme="red"
+              onClick={() => {
+                onChangeId?.(null);
+                deleteDisclosure.onClose();
+              }}
+            >
+              {t('programForm.deletePartnerOrg')}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
     </FormControl>
   );
 }


### PR DESCRIPTION
Creates a delete button for partner organization in program form

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a delete button with a confirmation modal to remove the selected partner organization in the program form. Includes new translations for en, es, fr, and zh.

- **New Features**
  - Delete icon appears when an organization is selected; opens a confirmation modal.
  - Confirm removes the organization (sets `onChangeId(null)`); cancel closes without changes.
  - New i18n keys for title, description, and action across en/es/fr/zh.

<sup>Written for commit 8bbe6501938be226c9d62fdc1b8c64b2bcd55ce4. Summary will update on new commits. <a href="https://cubic.dev/pr/ctc-uci/gcf/pull/165?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

