### PR TITLE
Add delete icon on hover for partner orgs in program form dropdown

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -365,6 +365,11 @@
     "saveSuccess": "Program saved successfully.",
     "saveError": "Failed to save program."
   },
+  "partnerOrg": {
+    "deleteTitle": "Delete this partner organization?",
+    "deleteDesc": "\"{{name}}\" will be permanently removed from the web app. This action cannot be undone.",
+    "deleteOrg": "Delete Organization"
+  },
   "locationForm": {
     "selectRegion": "Select region...",
     "selectCountry": "Select country...",

--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -293,7 +293,11 @@
   "instruments": {
     "searchPlaceholder": "Search instrument",
     "addNew": "Add new \"{{name}}\"",
-    "selected": "Selected: {{name}}"
+    "selected": "Selected: {{name}}",
+    "deleteTitle": "Delete this instrument?",
+    "deleteDesc": "\"{{name}}\" will be permanently removed from the web app. This action cannot be undone.",
+    "deleteInstrument": "Delete Instrument",
+    "deleteErrorTitle": "Failed to delete instrument"
   },
   "emptyState": {
     "noAccounts": "No accounts have been created yet. Click 'New Account' to get started.",

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -293,7 +293,11 @@
   "instruments": {
     "searchPlaceholder": "Instrumento de búsqueda",
     "addNew": "Agregar nuevo \"{{name}}\"",
-    "selected": "Seleccionado: {{name}}"
+    "selected": "Seleccionado: {{name}}",
+    "deleteTitle": "¿Eliminar este instrumento?",
+    "deleteDesc": "\"{{name}}\" se eliminará permanentemente de la aplicación. Esta acción no se puede deshacer.",
+    "deleteInstrument": "Eliminar instrumento",
+    "deleteErrorTitle": "Error al eliminar el instrumento"
   },
   "emptyState": {
     "noAccounts": "Aún no se han creado cuentas. Haga clic en 'Nueva cuenta' para comenzar.",

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -365,6 +365,11 @@
     "saveSuccess": "Programa guardado correctamente.",
     "saveError": "Error al guardar el programa."
   },
+  "partnerOrg": {
+    "deleteTitle": "¿Eliminar esta organización asociada?",
+    "deleteDesc": "\"{{name}}\" se eliminará permanentemente de la aplicación. Esta acción no se puede deshacer.",
+    "deleteOrg": "Eliminar organización"
+  },
   "locationForm": {
     "selectRegion": "Seleccionar región...",
     "selectCountry": "Seleccione país...",

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -365,6 +365,11 @@
     "saveSuccess": "Programme enregistré avec succès.",
     "saveError": "Échec de l'enregistrement du programme."
   },
+  "partnerOrg": {
+    "deleteTitle": "Supprimer cette organisation partenaire ?",
+    "deleteDesc": "\"{{name}}\" sera définitivement supprimée de l'application. Cette action est irréversible.",
+    "deleteOrg": "Supprimer l'organisation"
+  },
   "locationForm": {
     "selectRegion": "Sélectionnez la région...",
     "selectCountry": "Sélectionnez le pays...",

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -293,7 +293,11 @@
   "instruments": {
     "searchPlaceholder": "Instrument de recherche",
     "addNew": "Ajouter un nouveau \"{{name}}\"",
-    "selected": "Sélectionné : {{name}}"
+    "selected": "Sélectionné : {{name}}",
+    "deleteTitle": "Supprimer cet instrument ?",
+    "deleteDesc": "\"{{name}}\" sera definitivement supprime de l'application. Cette action est irreversible.",
+    "deleteInstrument": "Supprimer l'instrument",
+    "deleteErrorTitle": "Échec de la suppression de l'instrument"
   },
   "emptyState": {
     "noAccounts": "Aucun compte n'a encore été créé. Cliquez sur « Nouveau compte » pour commencer.",

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -295,7 +295,7 @@
     "addNew": "Ajouter un nouveau \"{{name}}\"",
     "selected": "Sélectionné : {{name}}",
     "deleteTitle": "Supprimer cet instrument ?",
-    "deleteDesc": "\"{{name}}\" sera definitivement supprime de l'application. Cette action est irreversible.",
+    "deleteDesc": "\"{{name}}\" sera définitivement supprimé de l'application. Cette action est irréversible.",
     "deleteInstrument": "Supprimer l'instrument",
     "deleteErrorTitle": "Échec de la suppression de l'instrument"
   },

--- a/client/public/locales/zh/translation.json
+++ b/client/public/locales/zh/translation.json
@@ -365,6 +365,11 @@
     "saveSuccess": "项目保存成功。",
     "saveError": "项目保存失败。"
   },
+  "partnerOrg": {
+    "deleteTitle": "删除此合作组织？",
+    "deleteDesc": "\"{{name}}\" 将从应用中永久删除。此操作无法撤销。",
+    "deleteOrg": "删除组织"
+  },
   "locationForm": {
     "selectRegion": "选择地区...",
     "selectCountry": "选择国家...",

--- a/client/src/components/common/SearchInput.jsx
+++ b/client/src/components/common/SearchInput.jsx
@@ -1,8 +1,10 @@
 import { useRef, useState } from 'react';
 
+import { DeleteIcon } from '@chakra-ui/icons';
 import {
   Box,
   HStack,
+  IconButton,
   Input,
   List,
   ListItem,
@@ -18,11 +20,13 @@ export function SearchInput({
   onChange,
   onSelectExisting,
   onCreateNew,
+  onDeleteItem,
   placeholder: placeholderProp,
 }) {
   const { t } = useTranslation();
   const placeholder = placeholderProp ?? t('instruments.searchPlaceholder');
   const [isOpen, setIsOpen] = useState(false);
+  const [hoveredId, setHoveredId] = useState(null);
   const containerRef = useRef(null);
 
   useOutsideClick({
@@ -100,8 +104,32 @@ export function SearchInput({
                 cursor="pointer"
                 _hover={{ bg: 'gray.100' }}
                 onClick={() => handleSelectExisting(item)}
+                onMouseEnter={
+                  onDeleteItem ? () => setHoveredId(item.id) : undefined
+                }
+                onMouseLeave={
+                  onDeleteItem ? () => setHoveredId(null) : undefined
+                }
               >
-                {item.name}
+                {onDeleteItem ? (
+                  <HStack justify="space-between">
+                    <Text flex={1}>{item.name}</Text>
+                    <IconButton
+                      size="xs"
+                      variant="ghost"
+                      colorScheme="red"
+                      icon={<DeleteIcon />}
+                      aria-label={`Delete ${item.name}`}
+                      visibility={hoveredId === item.id ? 'visible' : 'hidden'}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDeleteItem(item);
+                      }}
+                    />
+                  </HStack>
+                ) : (
+                  item.name
+                )}
               </ListItem>
             ))}
             {canAddNew && (

--- a/client/src/components/dashboard/ProgramForm/StudentsInstrumentsSection.jsx
+++ b/client/src/components/dashboard/ProgramForm/StudentsInstrumentsSection.jsx
@@ -8,6 +8,12 @@ import {
   Heading,
   HStack,
   Input,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
   NumberDecrementStepper,
   NumberIncrementStepper,
   NumberInput,
@@ -16,6 +22,7 @@ import {
   Tag,
   TagCloseButton,
   TagLabel,
+  useDisclosure,
   useToast,
   VStack,
 } from '@chakra-ui/react';
@@ -36,6 +43,8 @@ export function StudentsInstrumentsSection({ formState, setFormData }) {
   const [newInstrumentName, setNewInstrumentName] = useState('');
   /** Plain string so the field can be cleared while typing; validated on Add only. */
   const [quantityInput, setQuantityInput] = useState('1');
+  const [instrumentToDelete, setInstrumentToDelete] = useState(null);
+  const deleteDisclosure = useDisclosure();
 
   useEffect(() => {
     if (selectedInstrument && !Number.isNaN(Number(selectedInstrument))) {
@@ -172,182 +181,262 @@ export function StudentsInstrumentsSection({ formState, setFormData }) {
     });
   }
 
+  function handleDeleteClick(instrument) {
+    setInstrumentToDelete(instrument);
+    deleteDisclosure.onOpen();
+  }
+
+  async function handleConfirmDelete() {
+    if (!instrumentToDelete) return;
+    try {
+      await backend.delete(`/instruments/${instrumentToDelete.id}`);
+      setInstruments((prev) =>
+        prev.filter((i) => i.id !== instrumentToDelete.id)
+      );
+      removeInstrument(String(instrumentToDelete.id));
+      deleteDisclosure.onClose();
+      setInstrumentToDelete(null);
+    } catch (err) {
+      console.error('Error deleting instrument:', err);
+      toast({
+        title: t('instruments.deleteErrorTitle'),
+        description: err?.response?.data?.message ?? err?.message,
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    }
+  }
+
   return (
-    <Box>
-      <Heading
-        size="md"
-        fontWeight="semibold"
-        mb={3}
-      >
-        {t('programForm.studentsAndInstruments')}
-      </Heading>
-      <VStack
-        align="stretch"
-        spacing={3}
-      >
-        <FormControl>
-          <FormLabel
-            fontWeight="normal"
-            color="gray"
-          >
-            {t('programForm.currentStudents')}
-          </FormLabel>
-          <NumberInput
-            width="100%"
-            min={0}
-            value={formState.students}
-            onChange={(value) => {
-              const n = parseInt(value, 10);
-              setFormData((prev) => ({
-                ...prev,
-                students: Number.isNaN(n) ? 0 : n,
-              }));
-            }}
-          >
-            <NumberInputField />
-            <NumberInputStepper>
-              <NumberIncrementStepper />
-              <NumberDecrementStepper />
-            </NumberInputStepper>
-          </NumberInput>
-        </FormControl>
-
-        <FormControl>
-          <FormLabel
-            fontWeight="normal"
-            color="gray"
-          >
-            {t('programForm.graduatedStudentsLabel')}
-          </FormLabel>
-          <NumberInput
-            width="100%"
-            min={0}
-            value={formState.graduatedStudents}
-            onChange={(value) => {
-              const n = parseInt(value, 10);
-              setFormData((prev) => ({
-                ...prev,
-                graduatedStudents: Number.isNaN(n) ? 0 : n,
-              }));
-            }}
-          >
-            <NumberInputField />
-            <NumberInputStepper>
-              <NumberIncrementStepper />
-              <NumberDecrementStepper />
-            </NumberInputStepper>
-          </NumberInput>
-        </FormControl>
-
-        <FormControl>
-          <FormLabel
-            fontWeight="normal"
-            color="gray"
-          >
-            {t('programForm.instrumentAndQuantity')}
-          </FormLabel>
-          {!isAddingInstrument && (
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => {
-                setSearchQuery('');
-                setSelectedInstrument('');
-                setNewInstrumentName('');
-                setQuantityInput('1');
-                setIsAddingInstrument(true);
+    <>
+      <Box>
+        <Heading
+          size="md"
+          fontWeight="semibold"
+          mb={3}
+        >
+          {t('programForm.studentsAndInstruments')}
+        </Heading>
+        <VStack
+          align="stretch"
+          spacing={3}
+        >
+          <FormControl>
+            <FormLabel
+              fontWeight="normal"
+              color="gray"
+            >
+              {t('programForm.currentStudents')}
+            </FormLabel>
+            <NumberInput
+              width="100%"
+              min={0}
+              value={formState.students}
+              onChange={(value) => {
+                const n = parseInt(value, 10);
+                setFormData((prev) => ({
+                  ...prev,
+                  students: Number.isNaN(n) ? 0 : n,
+                }));
               }}
             >
-              {t('common.add')}
-            </Button>
-          )}
-          {isAddingInstrument && (
-            <Box
-              ref={instrumentAddRef}
-              mt={1}
-            >
-              <HStack
-                align="flex-end"
-                spacing={3}
-                flexWrap="wrap"
-              >
-                <Box
-                  flex="1"
-                  minW="12rem"
-                  maxW="16rem"
-                >
-                  <SearchInput
-                    items={instruments}
-                    value={searchQuery}
-                    onChange={(val) => setSearchQuery(val)}
-                    onSelectExisting={(instrument) => {
-                      setSelectedInstrument(String(instrument.id));
-                      setNewInstrumentName('');
-                      setSearchQuery('');
-                    }}
-                    onCreateNew={(name) => {
-                      setSelectedInstrument('');
-                      setNewInstrumentName(name.trim());
-                      setSearchQuery('');
-                    }}
-                  />
-                </Box>
-                <Input
-                  type="text"
-                  inputMode="numeric"
-                  value={quantityInput}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    if (v === '' || /^\d+$/.test(v)) {
-                      setQuantityInput(v);
-                    }
-                  }}
-                  width="5.5rem"
-                  aria-label={t('programForm.instrumentQuantityAria')}
-                />
-                <Button
-                  size="sm"
-                  variant="outline"
-                  onClick={async () => {
-                    const added = await handleAddInstrumentAndQuantity();
-                    if (added) setIsAddingInstrument(false);
-                  }}
-                >
-                  {t('common.add')}
-                </Button>
-              </HStack>
-            </Box>
-          )}
-        </FormControl>
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </FormControl>
 
-        {Object.keys(formState.instruments || {}).length > 0 && (
-          <HStack
-            width="100%"
-            flexWrap="wrap"
-            spacing={2}
-          >
-            {Object.entries(formState.instruments).map(
-              ([instrumentId, data]) => (
-                <Tag
-                  key={instrumentId}
-                  size="lg"
-                  bg="gray.200"
-                >
-                  <TagLabel>
-                    {t('programForm.instrumentQuantityPair', {
-                      name: data.name,
-                      qty: data.quantity,
-                    })}
-                  </TagLabel>
-                  <TagCloseButton
-                    onClick={() => removeInstrument(instrumentId)}
-                  />
-                </Tag>
-              )
+          <FormControl>
+            <FormLabel
+              fontWeight="normal"
+              color="gray"
+            >
+              {t('programForm.graduatedStudentsLabel')}
+            </FormLabel>
+            <NumberInput
+              width="100%"
+              min={0}
+              value={formState.graduatedStudents}
+              onChange={(value) => {
+                const n = parseInt(value, 10);
+                setFormData((prev) => ({
+                  ...prev,
+                  graduatedStudents: Number.isNaN(n) ? 0 : n,
+                }));
+              }}
+            >
+              <NumberInputField />
+              <NumberInputStepper>
+                <NumberIncrementStepper />
+                <NumberDecrementStepper />
+              </NumberInputStepper>
+            </NumberInput>
+          </FormControl>
+
+          <FormControl>
+            <FormLabel
+              fontWeight="normal"
+              color="gray"
+            >
+              {t('programForm.instrumentAndQuantity')}
+            </FormLabel>
+            {!isAddingInstrument && (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setSearchQuery('');
+                  setSelectedInstrument('');
+                  setNewInstrumentName('');
+                  setQuantityInput('1');
+                  setIsAddingInstrument(true);
+                }}
+              >
+                {t('common.add')}
+              </Button>
             )}
-          </HStack>
-        )}
-      </VStack>
-    </Box>
+            {isAddingInstrument && (
+              <Box
+                ref={instrumentAddRef}
+                mt={1}
+              >
+                <HStack
+                  align="flex-end"
+                  spacing={3}
+                  flexWrap="wrap"
+                >
+                  <Box
+                    flex="1"
+                    minW="12rem"
+                    maxW="16rem"
+                  >
+                    <SearchInput
+                      items={instruments}
+                      value={searchQuery}
+                      onChange={(val) => setSearchQuery(val)}
+                      onSelectExisting={(instrument) => {
+                        setSelectedInstrument(String(instrument.id));
+                        setNewInstrumentName('');
+                        setSearchQuery('');
+                      }}
+                      onCreateNew={(name) => {
+                        setSelectedInstrument('');
+                        setNewInstrumentName(name.trim());
+                        setSearchQuery('');
+                      }}
+                      onDeleteItem={handleDeleteClick}
+                    />
+                  </Box>
+                  <Input
+                    type="text"
+                    inputMode="numeric"
+                    value={quantityInput}
+                    onChange={(e) => {
+                      const v = e.target.value;
+                      if (v === '' || /^\d+$/.test(v)) {
+                        setQuantityInput(v);
+                      }
+                    }}
+                    width="5.5rem"
+                    aria-label={t('programForm.instrumentQuantityAria')}
+                  />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={async () => {
+                      const added = await handleAddInstrumentAndQuantity();
+                      if (added) setIsAddingInstrument(false);
+                    }}
+                  >
+                    {t('common.add')}
+                  </Button>
+                </HStack>
+              </Box>
+            )}
+          </FormControl>
+
+          {Object.keys(formState.instruments || {}).length > 0 && (
+            <HStack
+              width="100%"
+              flexWrap="wrap"
+              spacing={2}
+            >
+              {Object.entries(formState.instruments).map(
+                ([instrumentId, data]) => (
+                  <Tag
+                    key={instrumentId}
+                    size="lg"
+                    bg="gray.200"
+                  >
+                    <TagLabel>
+                      {t('programForm.instrumentQuantityPair', {
+                        name: data.name,
+                        qty: data.quantity,
+                      })}
+                    </TagLabel>
+                    <TagCloseButton
+                      onClick={() => removeInstrument(instrumentId)}
+                    />
+                  </Tag>
+                )
+              )}
+            </HStack>
+          )}
+        </VStack>
+      </Box>
+
+      <Modal
+        isOpen={deleteDisclosure.isOpen}
+        onClose={() => {
+          deleteDisclosure.onClose();
+          setInstrumentToDelete(null);
+        }}
+        isCentered
+      >
+        <ModalOverlay />
+        <ModalContent
+          borderRadius="md"
+          p={2}
+        >
+          <ModalHeader
+            fontSize="lg"
+            fontWeight="semibold"
+          >
+            {t('instruments.deleteTitle')}
+          </ModalHeader>
+
+          <ModalBody color="gray.600">
+            {t('instruments.deleteDesc', {
+              name: instrumentToDelete?.name ?? '',
+            })}
+          </ModalBody>
+
+          <ModalFooter
+            justifyContent="center"
+            gap={3}
+          >
+            <Button
+              onClick={() => {
+                deleteDisclosure.onClose();
+                setInstrumentToDelete(null);
+              }}
+              bg="gray.100"
+              _hover={{ bg: 'gray.200' }}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              colorScheme="red"
+              onClick={handleConfirmDelete}
+            >
+              {t('instruments.deleteInstrument')}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }

--- a/client/src/components/dashboard/ProgramForm/StudentsInstrumentsSection.jsx
+++ b/client/src/components/dashboard/ProgramForm/StudentsInstrumentsSection.jsx
@@ -194,6 +194,10 @@ export function StudentsInstrumentsSection({ formState, setFormData }) {
         prev.filter((i) => i.id !== instrumentToDelete.id)
       );
       removeInstrument(String(instrumentToDelete.id));
+      if (String(selectedInstrument) === String(instrumentToDelete.id)) {
+        setSelectedInstrument('');
+        setSearchQuery('');
+      }
       deleteDisclosure.onClose();
       setInstrumentToDelete(null);
     } catch (err) {

--- a/client/src/components/partners/PartnerOrganizationField.jsx
+++ b/client/src/components/partners/PartnerOrganizationField.jsx
@@ -1,18 +1,35 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { Box, FormControl, FormLabel, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useDisclosure,
+} from '@chakra-ui/react';
 
 import { SearchInput } from '@/components/common/SearchInput';
 import { useBackendContext } from '@/contexts/hooks/useBackendContext';
+import { useTranslation } from 'react-i18next';
 
 export function PartnerOrganizationField({
   valueId,
   onChangeId,
   label = 'Partner Organization',
 }) {
+  const { t } = useTranslation();
   const { backend } = useBackendContext();
   const [partnerOrgs, setPartnerOrgs] = useState([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [orgToDelete, setOrgToDelete] = useState(null);
+  const deleteDisclosure = useDisclosure();
 
   const selected = useMemo(() => {
     const idNum =
@@ -64,40 +81,105 @@ export function PartnerOrganizationField({
     }
   }
 
+  function handleDeleteClick(org) {
+    setOrgToDelete(org);
+    deleteDisclosure.onOpen();
+  }
+
+  async function handleConfirmDelete() {
+    if (!orgToDelete) return;
+    try {
+      await backend.delete(`/partners/${orgToDelete.id}`);
+      setPartnerOrgs((prev) => prev.filter((p) => p.id !== orgToDelete.id));
+      if (Number(valueId) === Number(orgToDelete.id)) {
+        onChangeId?.(null);
+      }
+      deleteDisclosure.onClose();
+      setOrgToDelete(null);
+    } catch (err) {
+      console.error('Error deleting partner organization:', err);
+    }
+  }
+
   return (
-    <FormControl isRequired>
-      <FormLabel
-        size="sm"
-        fontWeight="normal"
-        color="gray"
+    <>
+      <FormControl isRequired>
+        <FormLabel
+          size="sm"
+          fontWeight="normal"
+          color="gray"
+        >
+          {label}
+        </FormLabel>
+        <Box>
+          <SearchInput
+            items={partnerOrgs}
+            value={searchQuery}
+            onChange={(val) => setSearchQuery(val)}
+            onSelectExisting={(item) => {
+              onChangeId?.(item.id);
+              setSearchQuery('');
+            }}
+            onCreateNew={(name) => {
+              handleCreateNew(name);
+              setSearchQuery('');
+            }}
+            onDeleteItem={handleDeleteClick}
+            placeholder="Enter Partner Organization"
+          />
+          {selected && (
+            <Text
+              fontSize="sm"
+              color="gray.600"
+              mt={1}
+            >
+              Selected: {selected.name}
+            </Text>
+          )}
+        </Box>
+      </FormControl>
+
+      <Modal
+        isOpen={deleteDisclosure.isOpen}
+        onClose={deleteDisclosure.onClose}
+        isCentered
       >
-        {label}
-      </FormLabel>
-      <Box>
-        <SearchInput
-          items={partnerOrgs}
-          value={searchQuery}
-          onChange={(val) => setSearchQuery(val)}
-          onSelectExisting={(item) => {
-            onChangeId?.(item.id);
-            setSearchQuery('');
-          }}
-          onCreateNew={(name) => {
-            handleCreateNew(name);
-            setSearchQuery('');
-          }}
-          placeholder="Enter Partner Organization"
-        />
-        {selected && (
-          <Text
-            fontSize="sm"
-            color="gray.600"
-            mt={1}
+        <ModalOverlay />
+        <ModalContent
+          borderRadius="md"
+          p={2}
+        >
+          <ModalHeader
+            fontSize="lg"
+            fontWeight="semibold"
           >
-            Selected: {selected.name}
-          </Text>
-        )}
-      </Box>
-    </FormControl>
+            {t('partnerOrg.deleteTitle')}
+          </ModalHeader>
+
+          <ModalBody color="gray.600">
+            {t('partnerOrg.deleteDesc', { name: orgToDelete?.name ?? '' })}
+          </ModalBody>
+
+          <ModalFooter
+            justifyContent="center"
+            gap={3}
+          >
+            <Button
+              onClick={deleteDisclosure.onClose}
+              bg="gray.100"
+              _hover={{ bg: 'gray.200' }}
+            >
+              {t('common.cancel')}
+            </Button>
+            <Button
+              colorScheme="red"
+              onClick={handleConfirmDelete}
+            >
+              {t('partnerOrg.deleteOrg')}
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
   );
 }


### PR DESCRIPTION
Shows a per-row delete icon button in the partner organization search dropdown; clicking it opens a confirmation modal that permanently removes the organization via DELETE /partners/:id. Clears the selection if the deleted org was currently chosen. Adds partnerOrg i18n keys for all four locales.

## Description

## Screenshots/Media

## Issues
Closes #

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-row delete action to partner organization and instrument dropdowns in the program form. Users confirm in a modal; on delete we remove the item and clear the current selection or instrument entry.

- **New Features**
  - Hover-only delete icon in `SearchInput` dropdown rows.
  - Partner orgs: confirm, DELETE `/partners/:id`, remove from list; clear selection if chosen.
  - Instruments: confirm, DELETE `/instruments/:id`, remove from list and form data; show an error toast on failure.
  - i18n: add delete strings for `partnerOrg` (en/es/fr/zh) and `instruments` (en/es/fr).

<sup>Written for commit 244ab110387f4888480050af09d24b03d93c7225. Summary will update on new commits. <a href="https://cubic.dev/pr/ctc-uci/gcf/pull/166?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

