### PR TITLE
fix: resolved media updates action buttons removed

### DIFF
--- a/client/src/components/updates/forms/ReviewMediaUpdate.jsx
+++ b/client/src/components/updates/forms/ReviewMediaUpdate.jsx
@@ -36,6 +36,9 @@ export const ReviewMediaUpdate = ({ update, onClose, onUpdate }) => {
   const [updates, setUpdates] = useState([]);
   const [mediaURLs, setMediaURLs] = useState([]);
   const [selectedIndex, setSelectedIndex] = useState(null);
+  const isResolved = ['resolved', 'approved', 'active'].includes(
+    update?.status?.toLowerCase()
+  );
   const handleKeepUnresolved = () => {
     onClose();
   };
@@ -268,35 +271,37 @@ export const ReviewMediaUpdate = ({ update, onClose, onUpdate }) => {
             </VStack>
           </DrawerBody>
 
-          <Flex
-            position="absolute"
-            bottom={0}
-            left={0}
-            right={0}
-            bg="white"
-            borderTop="1px solid"
-            borderColor="gray.200"
-            px={8}
-            py={4}
-            justify="flex-end"
-            gap={3}
-          >
-            <Button
-              variant="outline"
-              onClick={handleKeepUnresolved}
+          {!isResolved && (
+            <Flex
+              position="absolute"
+              bottom={0}
+              left={0}
+              right={0}
+              bg="white"
+              borderTop="1px solid"
+              borderColor="gray.200"
+              px={8}
+              py={4}
+              justify="flex-end"
+              gap={3}
             >
-              {t('common.keepUnresolved')}
-            </Button>
-            <Button
-              bg="teal.500"
-              color="white"
-              _hover={{ bg: 'teal.600' }}
-              onClick={handleMarkResolved}
-              isLoading={isLoading}
-            >
-              {t('common.saveMarkResolved')}
-            </Button>
-          </Flex>
+              <Button
+                variant="outline"
+                onClick={handleKeepUnresolved}
+              >
+                {t('common.keepUnresolved')}
+              </Button>
+              <Button
+                bg="teal.500"
+                color="white"
+                _hover={{ bg: 'teal.600' }}
+                onClick={handleMarkResolved}
+                isLoading={isLoading}
+              >
+                {t('common.saveMarkResolved')}
+              </Button>
+            </Flex>
+          )}
         </DrawerContent>
       </Drawer>
       {selectedIndex !== null && (


### PR DESCRIPTION
## Description

Fixed a problem where resolved media updates were showing action buttons ("Keep as Unresolved" and "Save & Mark as Resolved"). Only unresolved media updates should have action buttons.

## Screenshots/Media

Resolved media update:

<img width="1512" height="863" alt="image" src="https://github.com/user-attachments/assets/fa978194-bdc6-43e3-8152-9d16cd3841cc" />

Unresolved media update:
<img width="1512" height="859" alt="image" src="https://github.com/user-attachments/assets/679ebc41-7303-47ff-b4b3-7d8899baf157" />


## Issues
Closes #187 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed action buttons from resolved media updates in the review view. Only unresolved updates now show "Keep Unresolved" and "Save & Mark as Resolved."

- **Bug Fixes**
  - Hid the action bar in `ReviewMediaUpdate` behind an `isResolved` check based on `update.status` values: `resolved`, `approved`, `active`.
  - Satisfies #187 by ensuring resolved updates are not actionable.

<sup>Written for commit afe1285d98ffba800030a4e7e19ff0c497d6c47d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/gcf/pull/196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

