### PR TITLE
fix: buttons no longer cutoff if media is too small

### DIFF
--- a/client/src/components/media/MediaCard.jsx
+++ b/client/src/components/media/MediaCard.jsx
@@ -18,6 +18,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Portal,
   Spacer,
   Text,
   useDisclosure,
@@ -107,8 +108,6 @@ export const MediaCard = ({
           <Menu
             isLazy
             placement="top-end"
-            gutter={0}
-            offset={[0, -40]}
           >
             <Box onClick={(e) => e.stopPropagation()}>
               <MenuButton
@@ -121,39 +120,38 @@ export const MediaCard = ({
                 right="0px"
                 zIndex={2}
               />
-              <MenuList
-                minW="150px"
-                p={0}
-                m={0}
-                boxShadow="xl"
-                border="none"
-                zIndex={3}
-                position="absolute"
-                top="0"
-                right="0"
-              >
-                <MenuItem onClick={onEditModalOpen}>
-                  <HStack w="full">
-                    <Text fontWeight="semibold">
-                      {t('mediaEditModal.heading')}
-                    </Text>
-                    <Spacer />
-                    <BsFillPencilFill />
-                  </HStack>
-                </MenuItem>
-                <MenuItem onClick={onDeleteOpen}>
-                  <HStack w="full">
-                    <Text
-                      color="red.500"
-                      fontWeight="semibold"
-                    >
-                      {t('common.delete')}
-                    </Text>
-                    <Spacer />
-                    <BsFillTrashFill />
-                  </HStack>
-                </MenuItem>
-              </MenuList>
+              <Portal>
+                <MenuList
+                  minW="150px"
+                  p={0}
+                  m={0}
+                  boxShadow="xl"
+                  border="none"
+                  zIndex="popover"
+                >
+                  <MenuItem onClick={onEditModalOpen}>
+                    <HStack w="full">
+                      <Text fontWeight="semibold">
+                        {t('mediaEditModal.heading')}
+                      </Text>
+                      <Spacer />
+                      <BsFillPencilFill />
+                    </HStack>
+                  </MenuItem>
+                  <MenuItem onClick={onDeleteOpen}>
+                    <HStack w="full">
+                      <Text
+                        color="red.500"
+                        fontWeight="semibold"
+                      >
+                        {t('common.delete')}
+                      </Text>
+                      <Spacer />
+                      <BsFillTrashFill />
+                    </HStack>
+                  </MenuItem>
+                </MenuList>
+              </Portal>
             </Box>
           </Menu>
         )}


### PR DESCRIPTION
## Description

Buttons used to cutoff if media was too small. Now they no longer cutoff and appear on top of the card.

## Screenshots/Media

Small media:

<img width="755" height="862" alt="image" src="https://github.com/user-attachments/assets/81164d64-4dca-415f-83a7-0bce8c3701d0" />

Big media:

<img width="769" height="774" alt="image" src="https://github.com/user-attachments/assets/233ba73d-4771-4c21-8353-791ab5368448" />

## Issues
Closes #186 
