### PR TITLE
fix: add message if no changes to countries in RegionsForm

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -47,6 +47,7 @@
     "exitWithoutSaving": "Exit Without Saving",
     "confirmChanges": "Confirm Changes",
     "reviewChanges": "Review changes",
+    "noChangesTo": "No changes made to {{field}}",
     "uploading": "Uploading...",
     "loading": "Loading...",
     "optional": "Optional for documentation",

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -47,6 +47,7 @@
     "exitWithoutSaving": "Salir sin guardar",
     "confirmChanges": "Confirmar cambios",
     "reviewChanges": "Revisar cambios",
+    "noChangesTo": "No se realizaron cambios en {{field}}",
     "uploading": "Subiendo...",
     "loading": "Cargando...",
     "optional": "Opcional para documentación",

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -47,6 +47,7 @@
     "exitWithoutSaving": "Quitter sans sauvegarder",
     "confirmChanges": "Confirmer les modifications",
     "reviewChanges": "Examiner les modifications",
+    "noChangesTo": "Aucune modification apportée à {{field}}",
     "uploading": "Téléchargement...",
     "loading": "Chargement...",
     "optional": "Facultatif pour la documentation",

--- a/client/public/locales/zh/translation.json
+++ b/client/public/locales/zh/translation.json
@@ -47,6 +47,7 @@
     "exitWithoutSaving": "退出而不保存",
     "confirmChanges": "确认更改",
     "reviewChanges": "审查变更",
+    "noChangesTo": "{{field}}未做任何更改",
     "uploading": "正在上传...",
     "loading": "加载中...",
     "optional": "文档可选",

--- a/client/src/components/regions/RegionsForm.jsx
+++ b/client/src/components/regions/RegionsForm.jsx
@@ -288,9 +288,7 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
           oldTags: (orig.directorIds || [])
             .filter((id) => !selectedDirectors.includes(id))
             .map(directorName),
-          newTags: selectedDirectors
-            .filter((id) => !(orig.directorIds || []).includes(id))
-            .map(directorName),
+          newTags: selectedDirectors.map(directorName),
         },
         {
           label: t('regions.assignedCountries'),
@@ -298,9 +296,7 @@ const RegionsForm = ({ isOpen, region, onClose, onSave, onDelete }) => {
           oldTags: (orig.countryNames || []).filter(
             (n) => !selectedCountries.map((c) => c.name).includes(n)
           ),
-          newTags: selectedCountries
-            .map((c) => c.name)
-            .filter((n) => !(orig.countryNames || []).includes(n)),
+          newTags: selectedCountries.map((c) => c.name),
         },
       ]);
       reviewDisclosure.onOpen();

--- a/client/src/components/updates/forms/ReviewProgramUpdate.jsx
+++ b/client/src/components/updates/forms/ReviewProgramUpdate.jsx
@@ -73,30 +73,39 @@ export const ReviewProgramUpdate = ({
                 </Text>
 
                 {field.isTag ? (
-                  <HStack
-                    wrap="wrap"
-                    spacing={2}
-                  >
-                    {field.oldTags?.map((tag, i) => (
-                      <Tag
-                        key={`old-${i}`}
-                        size="md"
-                        colorScheme="red"
-                        textDecoration="line-through"
-                      >
-                        {tag}
-                      </Tag>
-                    ))}
-                    {field.newTags?.map((tag, i) => (
-                      <Tag
-                        key={`new-${i}`}
-                        size="md"
-                        colorScheme="blue"
-                      >
-                        {tag}
-                      </Tag>
-                    ))}
-                  </HStack>
+                  !field.oldTags?.length && !field.newTags?.length ? (
+                    <Text
+                      color="gray.500"
+                      fontStyle="italic"
+                    >
+                      {t('common.noChangesTo', { field: field.label })}
+                    </Text>
+                  ) : (
+                    <HStack
+                      wrap="wrap"
+                      spacing={2}
+                    >
+                      {field.oldTags?.map((tag, i) => (
+                        <Tag
+                          key={`old-${i}`}
+                          size="md"
+                          colorScheme="red"
+                          textDecoration="line-through"
+                        >
+                          {tag}
+                        </Tag>
+                      ))}
+                      {field.newTags?.map((tag, i) => (
+                        <Tag
+                          key={`new-${i}`}
+                          size="md"
+                          colorScheme="blue"
+                        >
+                          {tag}
+                        </Tag>
+                      ))}
+                    </HStack>
+                  )
                 ) : (
                   <HStack
                     spacing={2}


### PR DESCRIPTION
## Description
- To match the rest of the modal, if there are no changes to countries it will just display the countries that are there already
- Only when there are no countries at all (as a fallback) does it display a "no changes" message

## Screenshots/Media

## Issues
Closes #193 

<!-- [Optional]
## Additional Notes
-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show existing countries and directors in the Review Changes modal when there are no edits, and only show “No changes to …” when the list is empty. Adds `common.noChangesTo` translations.

- **Bug Fixes**
  - In `RegionsForm`, pass current selections as `newTags` for directors and assigned countries so the modal shows the current state.
  - In `ReviewProgramUpdate`, display `common.noChangesTo` when both `oldTags` and `newTags` are empty.
  - Added `noChangesTo` to en/es/fr/zh translations.

<sup>Written for commit ab67231c6709df77203ba506dc0d1205ffb307e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/gcf/pull/199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

