### PR TITLE
fix: canceling account edits still saves updated profile picture

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -451,6 +451,8 @@
     "fieldRole": "Role",
     "fieldProgram": "Program",
     "fieldRegion": "Region",
+    "fieldProfilePicture": "Profile Picture",
+    "fieldProfilePictureUpdated": "Updated",
     "saveSuccess": "User saved successfully!",
     "emailExistsTitle": "Email already exists",
     "emailExistsDesc": "This email is already registered. Please use a different email address.",

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -451,6 +451,8 @@
     "fieldRole": "Rol",
     "fieldProgram": "Programa",
     "fieldRegion": "Región",
+    "fieldProfilePicture": "Foto de perfil",
+    "fieldProfilePictureUpdated": "Actualizada",
     "saveSuccess": "¡Usuario guardado exitosamente!",
     "emailExistsTitle": "El correo electrónico ya existe",
     "emailExistsDesc": "Este correo electrónico ya está registrado. Utilice una dirección de correo electrónico diferente.",

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -451,6 +451,8 @@
     "fieldRole": "Rôle",
     "fieldProgram": "Programme",
     "fieldRegion": "Région",
+    "fieldProfilePicture": "Photo de profil",
+    "fieldProfilePictureUpdated": "Mise à jour",
     "saveSuccess": "L'utilisateur a été enregistré avec succès !",
     "emailExistsTitle": "L'e-mail existe déjà",
     "emailExistsDesc": "Cet e-mail est déjà enregistré. Veuillez utiliser une autre adresse e-mail.",

--- a/client/public/locales/zh/translation.json
+++ b/client/public/locales/zh/translation.json
@@ -447,6 +447,8 @@
     "fieldRole": "角色",
     "fieldProgram": "程序",
     "fieldRegion": "地区",
+    "fieldProfilePicture": "头像",
+    "fieldProfilePictureUpdated": "已更新",
     "saveSuccess": "用户保存成功！",
     "emailExistsTitle": "电子邮件已存在",
     "emailExistsDesc": "此邮箱号已被注册。请使用不同的电子邮件地址。",

--- a/client/src/components/accounts/AccountForm/AccountFormDrawer.jsx
+++ b/client/src/components/accounts/AccountForm/AccountFormDrawer.jsx
@@ -544,6 +544,7 @@ export const AccountFormDrawer = ({
               <Button
                 variant="outline"
                 onClick={onCancel}
+                isDisabled={isLoading}
               >
                 {t('common.cancel')}
               </Button>

--- a/client/src/components/accounts/AccountForm/changedFields.js
+++ b/client/src/components/accounts/AccountForm/changedFields.js
@@ -1,6 +1,18 @@
-export function computeChangedFields(formData, initialFormData, t) {
+export function computeChangedFields(
+  formData,
+  initialFormData,
+  t,
+  pictureChanged = false
+) {
   const mask = t('accountForm.passwordMaskStars');
   const changes = [];
+  if (pictureChanged) {
+    changes.push({
+      label: t('accountForm.fieldProfilePicture'),
+      old: '',
+      new: t('accountForm.fieldProfilePictureUpdated'),
+    });
+  }
   if (formData.first_name !== initialFormData.first_name) {
     changes.push({
       label: t('accountForm.fieldFirstName'),

--- a/client/src/components/accounts/AccountForm/constants.js
+++ b/client/src/components/accounts/AccountForm/constants.js
@@ -36,6 +36,7 @@ export const formStateToAuditSnapshot = (fd, meta = {}) => ({
   ...(fd.role === 'Program Director'
     ? { bio: String(fd.bio ?? '').trim() || null }
     : {}),
+  ...(meta.picture !== undefined ? { picture: meta.picture } : {}),
   ...(meta.currentUserId !== undefined && meta.currentUserId !== null
     ? { currentUserId: meta.currentUserId }
     : {}),

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -331,13 +331,13 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
     if (!uploadedFiles?.length) return;
 
     const key = uploadedFiles[0].s3_key;
+    setProfilePictureKey(key);
 
     try {
       const urlResponse = await backend.get(
         `/images/url/${encodeURIComponent(key)}`
       );
 
-      setProfilePictureKey(key);
       setProfilePictureUrl(urlResponse.data.url || '');
     } catch (err) {
       console.error('Error loading profile picture preview:', err);

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -34,6 +34,7 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
   const [currentRegions, setCurrentRegions] = useState(null);
   const [profilePictureUrl, setProfilePictureUrl] = useState('');
   const [profilePictureKey, setProfilePictureKey] = useState('');
+  const [initialProfilePictureKey, setInitialProfilePictureKey] = useState('');
 
   const exitModal = useDisclosure();
   const deleteModal = useDisclosure();
@@ -46,12 +47,21 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
   });
 
   const isDirty = useMemo(() => {
-    return JSON.stringify(formData) !== JSON.stringify(initialFormData);
-  }, [formData, initialFormData]);
+    return (
+      JSON.stringify(formData) !== JSON.stringify(initialFormData) ||
+      profilePictureKey !== initialProfilePictureKey
+    );
+  }, [formData, initialFormData, profilePictureKey, initialProfilePictureKey]);
 
   const changedFields = useMemo(
-    () => computeChangedFields(formData, initialFormData, t),
-    [formData, initialFormData, t]
+    () =>
+      computeChangedFields(
+        formData,
+        initialFormData,
+        t,
+        profilePictureKey !== initialProfilePictureKey
+      ),
+    [formData, initialFormData, t, profilePictureKey, initialProfilePictureKey]
   );
 
   // Reset form when drawer opens
@@ -63,6 +73,7 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
     setIsFullScreen(false);
     setProfilePictureUrl('');
     setProfilePictureKey('');
+    setInitialProfilePictureKey('');
 
     if (!targetUser) {
       const newState = {
@@ -110,6 +121,7 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
             );
             setProfilePictureUrl(urlResponse.data.url || '');
             setProfilePictureKey(targetUser.picture);
+            setInitialProfilePictureKey(targetUser.picture);
           } catch {
             // picture unavailable — leave blank
           }
@@ -324,42 +336,11 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
       const urlResponse = await backend.get(
         `/images/url/${encodeURIComponent(key)}`
       );
-      const nextUrl = urlResponse.data.url || '';
-      const prevKey = profilePictureKey || null;
-
-      if (targetUserId) {
-        await backend.post('/images/profile-picture', {
-          key,
-          userId: targetUserId,
-        });
-
-        await logAccountChange({
-          user_id: String(targetUserId),
-          author_id: String(userId),
-          change_type: 'Update',
-          old_values: {
-            first_name: formData.first_name,
-            last_name: formData.last_name,
-            email: formData.email,
-            picture: prevKey,
-            bio: '',
-          },
-          new_values: {
-            first_name: formData.first_name,
-            last_name: formData.last_name,
-            email: formData.email,
-            picture: key,
-            bio: '',
-          },
-          resolved: false,
-          last_modified: new Date().toISOString(),
-        });
-      }
 
       setProfilePictureKey(key);
-      setProfilePictureUrl(nextUrl);
+      setProfilePictureUrl(urlResponse.data.url || '');
     } catch (err) {
-      console.error('Error saving profile picture:', err);
+      console.error('Error loading profile picture preview:', err);
     }
   };
 
@@ -439,6 +420,14 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
     }
     await backend.put('/gcf-users/admin/update-user', userData);
 
+    const pictureChanged = profilePictureKey !== initialProfilePictureKey;
+    if (pictureChanged) {
+      await backend.post('/images/profile-picture', {
+        key: profilePictureKey || null,
+        userId: targetUserId,
+      });
+    }
+
     if (userId) {
       await logAccountChange({
         user_id: String(targetUserId),
@@ -447,10 +436,14 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
         old_values: formStateToAuditSnapshot(initialFormData, {
           currentUserId: userId,
           targetId: targetUserId,
+          ...(pictureChanged
+            ? { picture: initialProfilePictureKey || null }
+            : {}),
         }),
         new_values: formStateToAuditSnapshot(formData, {
           currentUserId: userId,
           targetId: targetUserId,
+          ...(pictureChanged ? { picture: profilePictureKey || null } : {}),
         }),
         resolved: true,
         last_modified: new Date().toISOString(),

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useDisclosure, useToast } from '@chakra-ui/react';
 
@@ -35,6 +35,7 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
   const [profilePictureUrl, setProfilePictureUrl] = useState('');
   const [profilePictureKey, setProfilePictureKey] = useState('');
   const [initialProfilePictureKey, setInitialProfilePictureKey] = useState('');
+  const pictureRequestIdRef = useRef(0);
 
   const exitModal = useDisclosure();
   const deleteModal = useDisclosure();
@@ -114,14 +115,17 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
       }
 
       if (targetUser.picture) {
+        setProfilePictureKey(targetUser.picture);
+        setInitialProfilePictureKey(targetUser.picture);
+
+        const requestId = ++pictureRequestIdRef.current;
         const fetchPictureUrl = async () => {
           try {
             const urlResponse = await backend.get(
               `/images/url/${encodeURIComponent(targetUser.picture)}`
             );
+            if (pictureRequestIdRef.current !== requestId) return;
             setProfilePictureUrl(urlResponse.data.url || '');
-            setProfilePictureKey(targetUser.picture);
-            setInitialProfilePictureKey(targetUser.picture);
           } catch {
             // picture unavailable — leave blank
           }
@@ -333,11 +337,13 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
     const key = uploadedFiles[0].s3_key;
     setProfilePictureKey(key);
 
+    const requestId = ++pictureRequestIdRef.current;
     try {
       const urlResponse = await backend.get(
         `/images/url/${encodeURIComponent(key)}`
       );
 
+      if (pictureRequestIdRef.current !== requestId) return;
       setProfilePictureUrl(urlResponse.data.url || '');
     } catch (err) {
       console.error('Error loading profile picture preview:', err);

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -444,6 +444,7 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
         key: profilePictureKey || null,
         userId: targetUserId,
       });
+      setInitialProfilePictureKey(profilePictureKey);
     }
 
     await backend.put('/gcf-users/admin/update-user', userData);

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -343,7 +343,7 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
 
     setProfilePictureKey(key);
 
-    if (previousStagedKey) {
+    if (previousStagedKey && previousStagedKey !== key) {
       backend
         .delete(`/images/${encodeURIComponent(previousStagedKey)}`)
         .catch((err) => {

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -418,8 +418,6 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
     if (formData.password && formData.password.trim().length > 0) {
       userData.password = formData.password;
     }
-    await backend.put('/gcf-users/admin/update-user', userData);
-
     const pictureChanged = profilePictureKey !== initialProfilePictureKey;
     if (pictureChanged) {
       await backend.post('/images/profile-picture', {
@@ -427,6 +425,8 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
         userId: targetUserId,
       });
     }
+
+    await backend.put('/gcf-users/admin/update-user', userData);
 
     if (userId) {
       await logAccountChange({

--- a/client/src/components/accounts/AccountForm/index.jsx
+++ b/client/src/components/accounts/AccountForm/index.jsx
@@ -69,6 +69,7 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
   useEffect(() => {
     if (!isOpen) return;
 
+    pictureRequestIdRef.current += 1;
     setValidationErrors({});
     setShowPassword(false);
     setIsFullScreen(false);
@@ -335,7 +336,20 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
     if (!uploadedFiles?.length) return;
 
     const key = uploadedFiles[0].s3_key;
+    const previousStagedKey =
+      profilePictureKey && profilePictureKey !== initialProfilePictureKey
+        ? profilePictureKey
+        : null;
+
     setProfilePictureKey(key);
+
+    if (previousStagedKey) {
+      backend
+        .delete(`/images/${encodeURIComponent(previousStagedKey)}`)
+        .catch((err) => {
+          console.error('Error deleting replaced profile picture upload:', err);
+        });
+    }
 
     const requestId = ++pictureRequestIdRef.current;
     try {
@@ -579,6 +593,19 @@ export const AccountForm = ({ targetUser, isOpen, onClose, onSave }) => {
         isOpen={exitModal.isOpen}
         onClose={exitModal.onClose}
         onExitWithoutSaving={() => {
+          if (
+            profilePictureKey &&
+            profilePictureKey !== initialProfilePictureKey
+          ) {
+            backend
+              .delete(`/images/${encodeURIComponent(profilePictureKey)}`)
+              .catch((err) => {
+                console.error(
+                  'Error deleting unsaved profile picture upload:',
+                  err
+                );
+              });
+          }
           exitModal.onClose();
           onClose();
         }}

--- a/client/src/components/profile/ProfileView.jsx
+++ b/client/src/components/profile/ProfileView.jsx
@@ -179,6 +179,7 @@ export const ProfileView = (props) => {
               bottom={2}
               right={2}
               onClick={onOpen}
+              isDisabled={isSaving}
               _hover={{ bg: 'gray.100' }}
             />
           )}

--- a/client/src/components/profile/ProfileView.jsx
+++ b/client/src/components/profile/ProfileView.jsx
@@ -55,6 +55,7 @@ export const ProfileView = (props) => {
     role,
     roleSpecificData,
     isEditing,
+    isSaving,
     formData,
     showPassword,
     setShowPassword,
@@ -476,6 +477,7 @@ export const ProfileView = (props) => {
             leftIcon={<FiX />}
             variant="outline"
             onClick={handleCancel}
+            isDisabled={isSaving}
           >
             {t('common.cancel')}
           </Button>
@@ -485,6 +487,7 @@ export const ProfileView = (props) => {
             color="white"
             _hover={{ bg: 'teal.600' }}
             onClick={handleSave}
+            isLoading={isSaving}
           >
             {t('common.save')}
           </Button>

--- a/client/src/components/profile/useProfile.js
+++ b/client/src/components/profile/useProfile.js
@@ -35,6 +35,7 @@ export const useProfile = () => {
   const [newPassword, setNewPassword] = useState('');
 
   const profileEditBaselineRef = useRef(null);
+  const editSessionRef = useRef(0);
   const [pendingPictureKey, setPendingPictureKey] = useState(null);
   const [pendingPicturePreviewUrl, setPendingPicturePreviewUrl] =
     useState(null);
@@ -187,6 +188,7 @@ export const useProfile = () => {
     if (!uploadedFiles?.length) return;
 
     const key = uploadedFiles[0].s3_key;
+    const sessionId = editSessionRef.current;
     const previousStagedKey =
       pendingPictureKey && pendingPictureKey !== (gcfUser?.pictureKey || null)
         ? pendingPictureKey
@@ -196,6 +198,13 @@ export const useProfile = () => {
       const urlResponse = await backend.get(
         `/images/url/${encodeURIComponent(key)}`
       );
+
+      if (sessionId !== editSessionRef.current) {
+        backend.delete(`/images/${encodeURIComponent(key)}`).catch((err) => {
+          console.error('Error deleting stale profile picture upload:', err);
+        });
+        return;
+      }
 
       setPendingPictureKey(key);
       setPendingPicturePreviewUrl(urlResponse.data.url);
@@ -216,6 +225,7 @@ export const useProfile = () => {
   };
 
   const handleEdit = () => {
+    editSessionRef.current += 1;
     const prefLang =
       gcfUser.preferredLanguage &&
       isAppLocale(String(gcfUser.preferredLanguage))
@@ -241,6 +251,7 @@ export const useProfile = () => {
   };
 
   const handleCancel = () => {
+    editSessionRef.current += 1;
     if (
       pendingPictureKey &&
       pendingPictureKey !== (gcfUser?.pictureKey || null)
@@ -264,6 +275,7 @@ export const useProfile = () => {
   };
 
   const saveProfileEdits = async () => {
+    editSessionRef.current += 1;
     setIsSaving(true);
     try {
       if (role === 'Program Director') {

--- a/client/src/components/profile/useProfile.js
+++ b/client/src/components/profile/useProfile.js
@@ -36,6 +36,7 @@ export const useProfile = () => {
 
   const profileEditBaselineRef = useRef(null);
   const editSessionRef = useRef(0);
+  const isSavingRef = useRef(false);
   const [pendingPictureKey, setPendingPictureKey] = useState(null);
   const [pendingPicturePreviewUrl, setPendingPicturePreviewUrl] =
     useState(null);
@@ -188,6 +189,17 @@ export const useProfile = () => {
     if (!uploadedFiles?.length) return;
 
     const key = uploadedFiles[0].s3_key;
+
+    if (isSavingRef.current) {
+      backend.delete(`/images/${encodeURIComponent(key)}`).catch((err) => {
+        console.error(
+          'Error deleting profile picture uploaded during save:',
+          err
+        );
+      });
+      return;
+    }
+
     const sessionId = editSessionRef.current;
     const previousStagedKey =
       pendingPictureKey && pendingPictureKey !== (gcfUser?.pictureKey || null)
@@ -276,6 +288,7 @@ export const useProfile = () => {
 
   const saveProfileEdits = async () => {
     editSessionRef.current += 1;
+    isSavingRef.current = true;
     setIsSaving(true);
     try {
       if (role === 'Program Director') {
@@ -503,6 +516,7 @@ export const useProfile = () => {
         position: 'bottom-right',
       });
     } finally {
+      isSavingRef.current = false;
       setIsSaving(false);
     }
   };

--- a/client/src/components/profile/useProfile.js
+++ b/client/src/components/profile/useProfile.js
@@ -29,6 +29,7 @@ export const useProfile = () => {
   const [roleSpecificData, setRoleSpecificData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
   const [showPassword, setShowPassword] = useState(false);
   const [passwordEdited, setPasswordEdited] = useState(false);
   const [newPassword, setNewPassword] = useState('');
@@ -186,59 +187,29 @@ export const useProfile = () => {
     if (!uploadedFiles?.length) return;
 
     const key = uploadedFiles[0].s3_key;
+    const previousStagedKey =
+      pendingPictureKey && pendingPictureKey !== (gcfUser?.pictureKey || null)
+        ? pendingPictureKey
+        : null;
 
     try {
       const urlResponse = await backend.get(
         `/images/url/${encodeURIComponent(key)}`
       );
 
-      if (role === 'Program Director') {
-        setPendingPictureKey(key);
-        setPendingPicturePreviewUrl(urlResponse.data.url);
-        return;
-      }
+      setPendingPictureKey(key);
+      setPendingPicturePreviewUrl(urlResponse.data.url);
 
-      await backend.post('/images/profile-picture', {
-        key: key,
-        userId: currentUser.uid,
-      });
-
-      const prevPictureKey = gcfUser?.pictureKey || null;
-      const nextPictureKey = key;
-
-      if (prevPictureKey !== nextPictureKey) {
-        try {
-          await backend.post('/accountChange', {
-            user_id: currentUser.uid,
-            author_id: currentUser.uid,
-            change_type: 'Update',
-            old_values: {
-              first_name: gcfUser?.firstName || '',
-              last_name: gcfUser?.lastName || '',
-              email: currentUser?.email || '',
-              picture: prevPictureKey,
-              bio: '',
-            },
-            new_values: {
-              first_name: gcfUser?.firstName || '',
-              last_name: gcfUser?.lastName || '',
-              email: currentUser?.email || '',
-              picture: nextPictureKey,
-              bio: '',
-            },
-            resolved: false,
-            last_modified: new Date().toISOString(),
+      if (previousStagedKey && previousStagedKey !== key) {
+        backend
+          .delete(`/images/${encodeURIComponent(previousStagedKey)}`)
+          .catch((err) => {
+            console.error(
+              'Error deleting replaced profile picture upload:',
+              err
+            );
           });
-        } catch (changeErr) {
-          console.error('Error logging account change:', changeErr);
-        }
       }
-
-      setGcfUser((prev) => ({
-        ...prev,
-        pictureKey: nextPictureKey,
-        picture: urlResponse.data.url,
-      }));
     } catch (err) {
       console.error('Error saving profile picture:', err);
     }
@@ -270,6 +241,19 @@ export const useProfile = () => {
   };
 
   const handleCancel = () => {
+    if (
+      pendingPictureKey &&
+      pendingPictureKey !== (gcfUser?.pictureKey || null)
+    ) {
+      backend
+        .delete(`/images/${encodeURIComponent(pendingPictureKey)}`)
+        .catch((err) => {
+          console.error(
+            'Error deleting discarded profile picture upload:',
+            err
+          );
+        });
+    }
     setIsEditing(false);
     setShowPassword(false);
     setNewPassword('');
@@ -280,6 +264,7 @@ export const useProfile = () => {
   };
 
   const saveProfileEdits = async () => {
+    setIsSaving(true);
     try {
       if (role === 'Program Director') {
         const prefLang =
@@ -408,18 +393,22 @@ export const useProfile = () => {
         return;
       }
 
+      const prevPictureKey = gcfUser?.pictureKey || null;
+      const nextPictureKey = pendingPictureKey ?? prevPictureKey;
+      const pictureChanged = nextPictureKey !== prevPictureKey;
+
       const oldValues = {
         first_name: gcfUser?.firstName || '',
         last_name: gcfUser?.lastName || '',
         email: currentUser?.email || '',
-        picture: gcfUser?.pictureKey || null,
+        picture: prevPictureKey,
         bio: '',
       };
       const newValues = {
         first_name: formData.firstName,
         last_name: formData.lastName,
         email: currentUser?.email || '',
-        picture: gcfUser?.pictureKey || null,
+        picture: nextPictureKey,
         bio: '',
       };
 
@@ -427,6 +416,13 @@ export const useProfile = () => {
         first_name: formData.firstName,
         last_name: formData.lastName,
       });
+
+      if (pictureChanged) {
+        await backend.post('/images/profile-picture', {
+          key: nextPictureKey,
+          userId: currentUser.uid,
+        });
+      }
 
       if (JSON.stringify(oldValues) !== JSON.stringify(newValues)) {
         try {
@@ -454,7 +450,12 @@ export const useProfile = () => {
         preferredLanguage: formData.language,
         firstName: formData.firstName,
         lastName: formData.lastName,
+        ...(pictureChanged
+          ? { pictureKey: nextPictureKey, picture: pendingPicturePreviewUrl }
+          : {}),
       }));
+      setPendingPictureKey(null);
+      setPendingPicturePreviewUrl(null);
       window.dispatchEvent(new Event('profile-updated'));
 
       const now = new Date();
@@ -489,6 +490,8 @@ export const useProfile = () => {
         variant: 'subtle',
         position: 'bottom-right',
       });
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -532,12 +535,11 @@ export const useProfile = () => {
     setFormData((prev) => ({ ...prev, [field]: e.target.value }));
   };
 
-  const profilePicture =
-    pendingPicturePreviewUrl && role === 'Program Director'
-      ? pendingPicturePreviewUrl
-      : gcfUser?.picture && gcfUser.picture.trim() !== ''
-        ? gcfUser.picture
-        : DEFAULT_PROFILE_IMAGE;
+  const profilePicture = pendingPicturePreviewUrl
+    ? pendingPicturePreviewUrl
+    : gcfUser?.picture && gcfUser.picture.trim() !== ''
+      ? gcfUser.picture
+      : DEFAULT_PROFILE_IMAGE;
 
   const pdPending = role === 'Program Director' && !!pendingAccountChange;
   const ov = pendingAccountChange?.oldValues || {};
@@ -573,6 +575,7 @@ export const useProfile = () => {
     role,
     roleSpecificData,
     isEditing,
+    isSaving,
     formData,
     showPassword,
     setShowPassword,


### PR DESCRIPTION
## Description

Profile picture is only officially updated after pressing save. Previously, it would be saved even if the user pressed Cancel on the account form.

## Issues
Closes #185 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bug where canceling account or profile edits still saved a new profile picture. Previously, uploads committed immediately; now picture changes commit only on Save, and Cancel/exit keeps the original. Closes #185.

- Stage uploads for preview only; delete replaced or unsaved uploads on cancel/replace/exit, and never delete a committed picture.
- Prevent races by tagging requests with a session/request id; ignore and delete uploads that resolve after cancel/save (including uploads started during save).
- Make save atomic: commit the new picture on Save and then update the user; if the picture update fails, keep the prior picture and audit state unchanged.
- Treat the picture as dirty only if the key changes; show “Profile Picture → Updated” in Changed fields and include `picture` in audit snapshots when changed.
- While saving, disable Cancel (and Edit) and show Save loading in both the account drawer and profile view; add i18n for “Profile Picture” and “Updated” in `en`, `es`, `fr`, and `zh`.

<sup>Written for commit c17461463a2f0d92c094e52ec719cfea2752eba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/gcf/pull/201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

