### PR TITLE
fix: last expanded program is viewable

### DIFF
--- a/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
+++ b/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
@@ -40,26 +40,26 @@ export function ExpandableProgramRow({ p, onEdit }) {
     : '';
   const flagCode = isoCodeToFlagIconCode(p.isoCode);
 
-  const getScrollContainer = (node) => {
-    let current = node?.parentElement ?? null;
-
-    while (current) {
-      const style = window.getComputedStyle(current);
-      const overflowY = style.overflowY;
-      const canScrollY = overflowY === 'auto' || overflowY === 'scroll';
-      if (canScrollY && current.scrollHeight > current.clientHeight) {
-        return current;
-      }
-      current = current.parentElement;
-    }
-
-    return null;
-  };
-
   useEffect(() => {
     if (!isOpen) {
       return;
     }
+
+    const getScrollContainer = (node) => {
+      let current = node?.parentElement ?? null;
+
+      while (current) {
+        const style = window.getComputedStyle(current);
+        const overflowY = style.overflowY;
+        const canScrollY = overflowY === 'auto' || overflowY === 'scroll';
+        if (canScrollY && current.scrollHeight > current.clientHeight) {
+          return current;
+        }
+        current = current.parentElement;
+      }
+
+      return null;
+    };
 
     const ensureExpandedContentVisible = () => {
       const expandedNode = expandedContentRef.current;

--- a/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
+++ b/client/src/components/dashboard/ProgramTable/ExpandableProgramRow.jsx
@@ -1,3 +1,5 @@
+import { useEffect, useRef } from 'react';
+
 import {
   Box,
   Button,
@@ -28,6 +30,7 @@ import { StatusTag } from './StatusTag';
 export function ExpandableProgramRow({ p, onEdit }) {
   const { t } = useTranslation();
   const { isOpen, onToggle } = useDisclosure();
+  const expandedContentRef = useRef(null);
   const languageCodes = Array.isArray(p.languages) ? p.languages : [];
 
   const languageLabel = languageCodes.length
@@ -36,6 +39,71 @@ export function ExpandableProgramRow({ p, onEdit }) {
         .join(', ')
     : '';
   const flagCode = isoCodeToFlagIconCode(p.isoCode);
+
+  const getScrollContainer = (node) => {
+    let current = node?.parentElement ?? null;
+
+    while (current) {
+      const style = window.getComputedStyle(current);
+      const overflowY = style.overflowY;
+      const canScrollY = overflowY === 'auto' || overflowY === 'scroll';
+      if (canScrollY && current.scrollHeight > current.clientHeight) {
+        return current;
+      }
+      current = current.parentElement;
+    }
+
+    return null;
+  };
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const ensureExpandedContentVisible = () => {
+      const expandedNode = expandedContentRef.current;
+      if (!expandedNode) {
+        return;
+      }
+
+      const scrollContainer = getScrollContainer(expandedNode);
+      const bottomGap = 24;
+
+      if (scrollContainer) {
+        const containerRect = scrollContainer.getBoundingClientRect();
+        const rowRect = expandedNode.getBoundingClientRect();
+        const overflowBottom =
+          rowRect.bottom - (containerRect.bottom - bottomGap);
+
+        if (overflowBottom > 0) {
+          scrollContainer.scrollBy({
+            top: overflowBottom,
+            behavior: 'smooth',
+          });
+        }
+
+        return;
+      }
+
+      const rect = expandedNode.getBoundingClientRect();
+      const viewportBottom = window.innerHeight;
+      const overflowBottom = rect.bottom - (viewportBottom - bottomGap);
+
+      if (overflowBottom > 0) {
+        window.scrollBy({
+          top: overflowBottom,
+          behavior: 'smooth',
+        });
+      }
+    };
+
+    const timeoutId = window.setTimeout(ensureExpandedContentVisible, 240);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [isOpen]);
 
   return (
     <Tbody
@@ -157,6 +225,7 @@ export function ExpandableProgramRow({ p, onEdit }) {
         >
           <Collapse in={isOpen}>
             <HStack
+              ref={expandedContentRef}
               align="start"
               py={4}
             >


### PR DESCRIPTION
## Description
Before, expanding the last Program row could leave most of the expanded section hidden below the visible area because the viewport stayed in place.
Now, when a row is expanded near the bottom of the table, the dashboard automatically scrolls to keep the full expanded content visible.

## Screenshots/Media
Before:
https://github.com/user-attachments/assets/5382a24d-b46a-4fec-afaf-4e285a640566

After:
https://github.com/user-attachments/assets/00ec6b24-34ae-46d0-8eb5-aee2078d7fa9

## Issues
Closes #191 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hidden content when expanding the last Program row by auto-scrolling to keep the expanded section in view. Also resolves a missing `cubic` dependency.

- **Bug Fixes**
  - Auto-scrolls nearest scrollable container (or window) to reveal expanded content, with a 24px bottom gap and a 240ms post-expand delay.
  - Adds missing `cubic` dependency to prevent build/runtime errors.

<sup>Written for commit e97954e60306212c876320b3b208ea1eb1604dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/gcf/pull/202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

