### PR TITLE
fix: scrollbar now resets to the top when navigating between pages

### DIFF
--- a/client/src/components/navigation/Layout.jsx
+++ b/client/src/components/navigation/Layout.jsx
@@ -1,11 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { Box, Flex } from '@chakra-ui/react';
 
 import { useAuthContext } from '@/contexts/hooks/useAuthContext';
 import { useBackendContext } from '@/contexts/hooks/useBackendContext';
 import i18n, { isAppLocale } from '@/i18n';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import { Navbar } from './Navbar';
 import { Sidebar } from './Sidebar';
@@ -13,6 +13,8 @@ import { Sidebar } from './Sidebar';
 export const Layout = () => {
   const { currentUser } = useAuthContext();
   const { backend } = useBackendContext();
+  const location = useLocation();
+  const mainRef = useRef(null);
 
   useEffect(() => {
     if (!currentUser?.uid) return;
@@ -33,6 +35,12 @@ export const Layout = () => {
       cancelled = true;
     };
   }, [currentUser?.uid, backend]);
+
+  useEffect(() => {
+    const mainElement = mainRef.current;
+    if (!mainElement) return;
+    mainElement.scrollTop = 0;
+  }, [location.pathname]);
 
   return (
     <Flex
@@ -56,6 +64,7 @@ export const Layout = () => {
         <Navbar />
         <Box
           as="main"
+          ref={mainRef}
           mt={6}
           flex="1"
           minW={0}


### PR DESCRIPTION
## Description
Scrollbar now resets to the top on every route change instead of retaining the previous page's location.

## Screenshots/Media
[Screen Recording 2026-08-07 190354.mp3](https://github.com/user-attachments/files/30849093/Screen.Recording.2026-08-07.190354.mp3)


## Issues
Closes #195 