### PR TITLE
fix(#189): add better validation for program form

### DIFF
--- a/client/public/locales/en/translation.json
+++ b/client/public/locales/en/translation.json
@@ -374,6 +374,7 @@
       "statusRequired": "Please select a status.",
       "launchDateRequired": "Please enter a valid date.",
       "partnerOrgRequired": "Please select a partner organization.",
+      "regionRequired": "Please select a region.",
       "countryRequired": "Please select a country."
     }
   },

--- a/client/public/locales/es/translation.json
+++ b/client/public/locales/es/translation.json
@@ -374,6 +374,7 @@
       "statusRequired": "Seleccione un estado.",
       "launchDateRequired": "Introduzca una fecha válida.",
       "partnerOrgRequired": "Seleccione una organización asociada.",
+      "regionRequired": "Seleccione una región.",
       "countryRequired": "Seleccione un país."
     }
   },

--- a/client/public/locales/fr/translation.json
+++ b/client/public/locales/fr/translation.json
@@ -374,6 +374,7 @@
       "statusRequired": "Veuillez sélectionner un statut.",
       "launchDateRequired": "Veuillez saisir une date valide.",
       "partnerOrgRequired": "Veuillez sélectionner une organisation partenaire.",
+      "regionRequired": "Veuillez sélectionner une région.",
       "countryRequired": "Veuillez sélectionner un pays."
     }
   },

--- a/client/public/locales/zh/translation.json
+++ b/client/public/locales/zh/translation.json
@@ -370,6 +370,7 @@
       "statusRequired": "请选择状态。",
       "launchDateRequired": "请输入有效日期。",
       "partnerOrgRequired": "请选择合作机构。",
+      "regionRequired": "请选择地区。",
       "countryRequired": "请选择国家。"
     }
   },

--- a/client/src/components/dashboard/ProgramForm/LocationLanguageSection.jsx
+++ b/client/src/components/dashboard/ProgramForm/LocationLanguageSection.jsx
@@ -122,7 +122,7 @@ export function LocationLanguageSection({
             `/program-directors/me/${userId}/region`
           );
           setRegionList([response.data]);
-        } else if (role === 'Admin') {
+        } else if (role === 'Admin' || role === 'Super Admin') {
           const response = await backend.get('/region');
           setRegionList(response.data);
         } else {
@@ -284,20 +284,26 @@ export function LocationLanguageSection({
             gap={6}
           >
             <GridItem>
-              <Select
-                onChange={(e) => handleRegionChange(e.target.value)}
-                placeholder={t('locationForm.selectRegion')}
-                value={formState.regionId || ''}
-              >
-                {regionList.map((_region) => (
-                  <option
-                    key={_region.id}
-                    value={_region.id}
-                  >
-                    {_region.name}
-                  </option>
-                ))}
-              </Select>
+              <FormControl isInvalid={Boolean(fieldErrors.regionId)}>
+                <Select
+                  onChange={(e) => {
+                    handleRegionChange(e.target.value);
+                    onClearProgramFieldError?.('regionId');
+                  }}
+                  placeholder={t('locationForm.selectRegion')}
+                  value={formState.regionId || ''}
+                >
+                  {regionList.map((_region) => (
+                    <option
+                      key={_region.id}
+                      value={_region.id}
+                    >
+                      {_region.name}
+                    </option>
+                  ))}
+                </Select>
+                <FormErrorMessage>{fieldErrors.regionId}</FormErrorMessage>
+              </FormControl>
             </GridItem>
 
             <GridItem>

--- a/client/src/components/dashboard/ProgramForm/LocationLanguageSection.jsx
+++ b/client/src/components/dashboard/ProgramForm/LocationLanguageSection.jsx
@@ -289,6 +289,7 @@ export function LocationLanguageSection({
                   onChange={(e) => {
                     handleRegionChange(e.target.value);
                     onClearProgramFieldError?.('regionId');
+                    onClearProgramFieldError?.('country');
                   }}
                   placeholder={t('locationForm.selectRegion')}
                   value={formState.regionId || ''}

--- a/client/src/components/dashboard/ProgramForm/programFormValidation.js
+++ b/client/src/components/dashboard/ProgramForm/programFormValidation.js
@@ -27,11 +27,7 @@ export function validateProgramForm(formState, { isNewProgram }, t) {
   }
 
   const status = formState.status;
-  if (
-    status === null ||
-    status === undefined ||
-    String(status).trim() === ''
-  ) {
+  if (status === null || status === undefined || String(status).trim() === '') {
     errors.status = t('programForm.validation.statusRequired');
   }
 
@@ -58,14 +54,24 @@ export function validateProgramForm(formState, { isNewProgram }, t) {
     }
   }
 
-  const countryRaw = formState.country;
-  const hasCountry =
-    countryRaw !== null &&
-    countryRaw !== undefined &&
-    countryRaw !== '' &&
-    !Number.isNaN(Number(countryRaw));
-  if (!hasCountry) {
-    errors.country = t('programForm.validation.countryRequired');
+  const regionRaw = formState.regionId;
+  const hasRegion =
+    regionRaw !== null &&
+    regionRaw !== undefined &&
+    regionRaw !== '' &&
+    !Number.isNaN(Number(regionRaw));
+  if (!hasRegion) {
+    errors.regionId = t('programForm.validation.regionRequired');
+  } else {
+    const countryRaw = formState.country;
+    const hasCountry =
+      countryRaw !== null &&
+      countryRaw !== undefined &&
+      countryRaw !== '' &&
+      !Number.isNaN(Number(countryRaw));
+    if (!hasCountry) {
+      errors.country = t('programForm.validation.countryRequired');
+    }
   }
 
   return errors;


### PR DESCRIPTION
## Description
Fixed location validation in the program edit form:

- Super Admin region loading: `Super Admin` wasn't handled in the `getRegions` role check, leaving the region dropdown empty and making location fields non-interactive for test user. This caused removed values to appear "restored" on reopen since they were never cleared from form state.

- Region/country validation: `regionId` is now a required field. Country is only validated once a region is selected, so errors appear one step at a time.

> [!NOTE]
> I was not able to reproduce the lack of client-side validation errors mentioned in #189 on dev (despite seeing them on production). I did observe that the validation errors for region and location could have been improved on which is what I focused on here.

## Screenshots/Media
| Before | After |
| :---: | :---: |
| <img width="1344" alt="Before" src="https://github.com/user-attachments/assets/f9f9b65e-ae16-4f02-8e90-eb1bb1517689" /> | <img width="1344" alt="After" src="https://github.com/user-attachments/assets/1aab87c6-49fe-4dd8-ab4d-ef61ece48f0e" /> |

## Issues
Closes #189 

<!-- [Optional]
## Additional Notes
-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes region loading and location validation in the program edit form. `Super Admin` now sees regions, and the form shows step-by-step errors for region and country (addresses #189).

- **Bug Fixes**
  - Load regions for `Super Admin` in `LocationLanguageSection`.
  - Require `regionId`; validate country only after a region is selected.
  - Show region errors under the dropdown; clear region and country errors when the region changes.
  - Add `regionRequired` i18n key in `en`, `es`, `fr`, and `zh`.

<sup>Written for commit 09873eae981eef52dd6565f3ffb98405fb452915. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ctc-uci/gcf/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

